### PR TITLE
🚀 1단계 - 인수 테스트 기반 리팩터링

### DIFF
--- a/src/main/java/nextstep/subway/line/application/LineSectionService.java
+++ b/src/main/java/nextstep/subway/line/application/LineSectionService.java
@@ -1,0 +1,51 @@
+package nextstep.subway.line.application;
+
+import nextstep.subway.line.domain.Line;
+import nextstep.subway.line.domain.LineRepository;
+import nextstep.subway.line.domain.Section;
+import nextstep.subway.line.dto.SectionRequest;
+import nextstep.subway.station.application.StationService;
+import nextstep.subway.station.domain.Station;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * @author : leesangbae
+ * @project : subway
+ * @since : 2021-01-02
+ */
+@Service
+@Transactional
+public class LineSectionService {
+
+    private final LineRepository lineRepository;
+    private final StationService stationService;
+
+    public LineSectionService(LineRepository lineRepository,
+            StationService stationService) {
+        this.lineRepository = lineRepository;
+        this.stationService = stationService;
+    }
+
+    public void addSection(Long lineId, SectionRequest request) {
+        Line line = findLineById(lineId);
+
+        Station upStation = stationService.findStationById(request.getUpStationId());
+        Station downStation = stationService.findStationById(request.getDownStationId());
+
+        Section section = new Section(line, upStation, downStation, request.getDistance());
+        line.addSection(section);
+    }
+
+    public void removeSection(Long lineId, Long stationId) {
+        Line line = findLineById(lineId);
+        Station station = stationService.findStationById(stationId);
+
+        line.removeSection(line, station);
+    }
+
+    private Line findLineById(Long id) {
+        return lineRepository.findById(id).orElseThrow(RuntimeException::new);
+    }
+
+}

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -28,31 +28,20 @@ public class LineService {
         Station upStation = stationService.findById(request.getUpStationId());
         Station downStation = stationService.findById(request.getDownStationId());
         Line persistLine = lineRepository.save(new Line(request.getName(), request.getColor(), upStation, downStation, request.getDistance()));
-        List<StationResponse> stations = getStations(persistLine).stream()
-                .map(it -> StationResponse.of(it))
-                .collect(Collectors.toList());
-        return LineResponse.of(persistLine, stations);
+        return LineResponse.of(persistLine);
     }
 
     @Transactional(readOnly = true)
     public List<LineResponse> findLines() {
         List<Line> persistLines = lineRepository.findAll();
         return persistLines.stream()
-                .map(line -> {
-                    List<StationResponse> stations = getStations(line).stream()
-                            .map(it -> StationResponse.of(it))
-                            .collect(Collectors.toList());
-                    return LineResponse.of(line, stations);
-                })
+                .map(LineResponse::of)
                 .collect(Collectors.toList());
     }
 
     public LineResponse findLineResponseById(Long id) {
         Line persistLine = findLineById(id);
-        List<StationResponse> stations = getStations(persistLine).stream()
-                .map(it -> StationResponse.of(it))
-                .collect(Collectors.toList());
-        return LineResponse.of(persistLine, stations);
+        return LineResponse.of(persistLine);
     }
 
     public void updateLine(Long id, LineRequest lineUpdateRequest) {

--- a/src/main/java/nextstep/subway/line/application/LineService.java
+++ b/src/main/java/nextstep/subway/line/application/LineService.java
@@ -2,27 +2,22 @@ package nextstep.subway.line.application;
 
 import nextstep.subway.line.domain.Line;
 import nextstep.subway.line.domain.LineRepository;
-import nextstep.subway.line.domain.Section;
 import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
-import nextstep.subway.line.dto.SectionRequest;
 import nextstep.subway.station.application.StationService;
 import nextstep.subway.station.domain.Station;
-import nextstep.subway.station.dto.StationResponse;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Service
 @Transactional
 public class LineService {
-    private LineRepository lineRepository;
-    private StationService stationService;
+
+    private final LineRepository lineRepository;
+    private final StationService stationService;
 
     public LineService(LineRepository lineRepository, StationService stationService) {
         this.lineRepository = lineRepository;
@@ -39,6 +34,7 @@ public class LineService {
         return LineResponse.of(persistLine, stations);
     }
 
+    @Transactional(readOnly = true)
     public List<LineResponse> findLines() {
         List<Line> persistLines = lineRepository.findAll();
         return persistLines.stream()
@@ -50,11 +46,6 @@ public class LineService {
                 })
                 .collect(Collectors.toList());
     }
-
-    public Line findLineById(Long id) {
-        return lineRepository.findById(id).orElseThrow(RuntimeException::new);
-    }
-
 
     public LineResponse findLineResponseById(Long id) {
         Line persistLine = findLineById(id);
@@ -73,110 +64,7 @@ public class LineService {
         lineRepository.deleteById(id);
     }
 
-    public void addLineStation(Long lineId, SectionRequest request) {
-        Line line = findLineById(lineId);
-        Station upStation = stationService.findStationById(request.getUpStationId());
-        Station downStation = stationService.findStationById(request.getDownStationId());
-        List<Station> stations = getStations(line);
-        boolean isUpStationExisted = stations.stream().anyMatch(it -> it == upStation);
-        boolean isDownStationExisted = stations.stream().anyMatch(it -> it == downStation);
-
-        if (isUpStationExisted && isDownStationExisted) {
-            throw new RuntimeException("이미 등록된 구간 입니다.");
-        }
-
-        if (!stations.isEmpty() && stations.stream().noneMatch(it -> it == upStation) &&
-                stations.stream().noneMatch(it -> it == downStation)) {
-            throw new RuntimeException("등록할 수 없는 구간 입니다.");
-        }
-
-        if (stations.isEmpty()) {
-            line.getSections().add(new Section(line, upStation, downStation, request.getDistance()));
-            return;
-        }
-
-        if (isUpStationExisted) {
-            line.getSections().stream()
-                    .filter(it -> it.getUpStation() == upStation)
-                    .findFirst()
-                    .ifPresent(it -> it.updateUpStation(downStation, request.getDistance()));
-
-            line.getSections().add(new Section(line, upStation, downStation, request.getDistance()));
-        } else if (isDownStationExisted) {
-            line.getSections().stream()
-                    .filter(it -> it.getDownStation() == downStation)
-                    .findFirst()
-                    .ifPresent(it -> it.updateDownStation(upStation, request.getDistance()));
-
-            line.getSections().add(new Section(line, upStation, downStation, request.getDistance()));
-        } else {
-            throw new RuntimeException();
-        }
-    }
-
-    public void removeLineStation(Long lineId, Long stationId) {
-        Line line = findLineById(lineId);
-        Station station = stationService.findStationById(stationId);
-        if (line.getSections().size() <= 1) {
-            throw new RuntimeException();
-        }
-
-        Optional<Section> upLineStation = line.getSections().stream()
-                .filter(it -> it.getUpStation() == station)
-                .findFirst();
-        Optional<Section> downLineStation = line.getSections().stream()
-                .filter(it -> it.getDownStation() == station)
-                .findFirst();
-
-        if (upLineStation.isPresent() && downLineStation.isPresent()) {
-            Station newUpStation = downLineStation.get().getUpStation();
-            Station newDownStation = upLineStation.get().getDownStation();
-            int newDistance = upLineStation.get().getDistance() + downLineStation.get().getDistance();
-            line.getSections().add(new Section(line, newUpStation, newDownStation, newDistance));
-        }
-
-        upLineStation.ifPresent(it -> line.getSections().remove(it));
-        downLineStation.ifPresent(it -> line.getSections().remove(it));
-    }
-
-
-    public List<Station> getStations(Line line) {
-        if (line.getSections().isEmpty()) {
-            return Arrays.asList();
-        }
-
-        List<Station> stations = new ArrayList<>();
-        Station downStation = findUpStation(line);
-        stations.add(downStation);
-
-        while (downStation != null) {
-            Station finalDownStation = downStation;
-            Optional<Section> nextLineStation = line.getSections().stream()
-                    .filter(it -> it.getUpStation() == finalDownStation)
-                    .findFirst();
-            if (!nextLineStation.isPresent()) {
-                break;
-            }
-            downStation = nextLineStation.get().getDownStation();
-            stations.add(downStation);
-        }
-
-        return stations;
-    }
-
-    private Station findUpStation(Line line) {
-        Station downStation = line.getSections().get(0).getUpStation();
-        while (downStation != null) {
-            Station finalDownStation = downStation;
-            Optional<Section> nextLineStation = line.getSections().stream()
-                    .filter(it -> it.getDownStation() == finalDownStation)
-                    .findFirst();
-            if (!nextLineStation.isPresent()) {
-                break;
-            }
-            downStation = nextLineStation.get().getUpStation();
-        }
-
-        return downStation;
+    private Line findLineById(Long id) {
+        return lineRepository.findById(id).orElseThrow(RuntimeException::new);
     }
 }

--- a/src/main/java/nextstep/subway/line/domain/Line.java
+++ b/src/main/java/nextstep/subway/line/domain/Line.java
@@ -4,7 +4,6 @@ import nextstep.subway.BaseEntity;
 import nextstep.subway.station.domain.Station;
 
 import javax.persistence.*;
-import java.util.ArrayList;
 import java.util.List;
 
 @Entity
@@ -16,10 +15,10 @@ public class Line extends BaseEntity {
     private String name;
     private String color;
 
-    @OneToMany(mappedBy = "line", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
-    private List<Section> sections = new ArrayList<>();
+    @Embedded
+    private Sections sections = new Sections();
 
-    public Line() {
+    protected Line() {
     }
 
     public Line(String name, String color) {
@@ -50,7 +49,15 @@ public class Line extends BaseEntity {
         return color;
     }
 
-    public List<Section> getSections() {
-        return sections;
+    public List<Station> getStations() {
+        return sections.getStations();
+    }
+
+    public void addSection(Section section) {
+        sections.add(section);
+    }
+
+    public void removeSection(Line line, Station station) {
+        sections.remove(line, station);
     }
 }

--- a/src/main/java/nextstep/subway/line/domain/Section.java
+++ b/src/main/java/nextstep/subway/line/domain/Section.java
@@ -24,7 +24,7 @@ public class Section {
 
     private int distance;
 
-    public Section() {
+    protected Section() {
     }
 
     public Section(Line line, Station upStation, Station downStation, int distance) {

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -1,6 +1,13 @@
 package nextstep.subway.line.domain;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import javax.persistence.CascadeType;
 import javax.persistence.Embeddable;
+import javax.persistence.OneToMany;
+import nextstep.subway.station.domain.Station;
 
 /**
  * @author : leesangbae
@@ -14,9 +21,115 @@ public class Sections {
     private List<Section> sections = new ArrayList<>();
 
     public void add(Section section) {
+        if (sections.isEmpty()) {
+            this.sections.add(section);
+            return;
+        }
+
+        boolean isUpStationExisted = contains(section.getUpStation());
+        boolean isDownStationExisted = contains(section.getDownStation());
+
+        validate(isUpStationExisted, isDownStationExisted);
+
+        if (isUpStationExisted) {
+            this.sections.stream()
+                    .filter(it -> it.getUpStation() == section.getUpStation())
+                    .findFirst()
+                    .ifPresent(it -> it.updateUpStation(section.getDownStation(), section.getDistance()));
+            this.sections.add(section);
+            return;
+        }
+
+        if (isDownStationExisted) {
+            this.sections.stream()
+                    .filter(it -> it.getDownStation() == section.getDownStation())
+                    .findFirst()
+                    .ifPresent(it -> it.updateDownStation(section.getUpStation(), section.getDistance()));
+            this.sections.add(section);
+            return;
+        }
+
+        throw new RuntimeException();
     }
 
 
     public void remove(Line line, Station station) {
+
+        if (this.sections.size() <= 1) {
+            throw new RuntimeException();
+        }
+
+        Optional<Section> upLineStation = this.sections.stream()
+                .filter(it -> it.getUpStation() == station)
+                .findFirst();
+        Optional<Section> downLineStation = this.sections.stream()
+                .filter(it -> it.getDownStation() == station)
+                .findFirst();
+
+        if (upLineStation.isPresent() && downLineStation.isPresent()) {
+            Station newUpStation = downLineStation.get().getUpStation();
+            Station newDownStation = upLineStation.get().getDownStation();
+            int newDistance = upLineStation.get().getDistance() + downLineStation.get().getDistance();
+            this.sections.add(new Section(line, newUpStation, newDownStation, newDistance));
+        }
+
+        upLineStation.ifPresent(it -> this.sections.remove(it));
+        downLineStation.ifPresent(it -> this.sections.remove(it));
+    }
+
+
+    public List<Station> getStations() {
+        if (this.sections.isEmpty()) {
+            return Arrays.asList();
+        }
+
+        List<Station> stations = new ArrayList<>();
+        Station downStation = findUpStation();
+        stations.add(downStation);
+
+        while (downStation != null) {
+            Station finalDownStation = downStation;
+            Optional<Section> nextLineStation = this.sections.stream()
+                    .filter(it -> it.getUpStation() == finalDownStation)
+                    .findFirst();
+            if (!nextLineStation.isPresent()) {
+                break;
+            }
+            downStation = nextLineStation.get().getDownStation();
+            stations.add(downStation);
+        }
+
+        return stations;
+    }
+
+    private Station findUpStation() {
+        Station downStation = this.sections.get(0).getUpStation();
+        while (downStation != null) {
+            Station finalDownStation = downStation;
+            Optional<Section> nextLineStation = this.sections.stream()
+                    .filter(it -> it.getDownStation() == finalDownStation)
+                    .findFirst();
+            if (!nextLineStation.isPresent()) {
+                break;
+            }
+            downStation = nextLineStation.get().getUpStation();
+        }
+
+        return downStation;
+    }
+
+    private boolean contains(Station station) {
+        return this.sections.stream()
+                .anyMatch(it -> it.getUpStation() == station || it.getDownStation() == station);
+    }
+
+    private void validate(boolean isUpStationExisted, boolean isDownStationExisted) {
+        if (isUpStationExisted && isDownStationExisted) {
+            throw new RuntimeException("이미 등록된 구간 입니다.");
+        }
+
+        if (!isUpStationExisted && !isDownStationExisted) {
+            throw new RuntimeException("등록할 수 없는 구간 입니다.");
+        }
     }
 }

--- a/src/main/java/nextstep/subway/line/domain/Sections.java
+++ b/src/main/java/nextstep/subway/line/domain/Sections.java
@@ -1,0 +1,22 @@
+package nextstep.subway.line.domain;
+
+import javax.persistence.Embeddable;
+
+/**
+ * @author : leesangbae
+ * @project : subway
+ * @since : 2021-01-02
+ */
+@Embeddable
+public class Sections {
+
+    @OneToMany(mappedBy = "line", cascade = {CascadeType.PERSIST, CascadeType.MERGE}, orphanRemoval = true)
+    private List<Section> sections = new ArrayList<>();
+
+    public void add(Section section) {
+    }
+
+
+    public void remove(Line line, Station station) {
+    }
+}

--- a/src/main/java/nextstep/subway/line/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/line/dto/LineResponse.java
@@ -1,5 +1,6 @@
 package nextstep.subway.line.dto;
 
+import java.util.stream.Collectors;
 import nextstep.subway.line.domain.Line;
 import nextstep.subway.station.dto.StationResponse;
 
@@ -14,10 +15,7 @@ public class LineResponse {
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
 
-    public LineResponse() {
-    }
-
-    public LineResponse(Long id, String name, String color, List<StationResponse> stations, LocalDateTime createdDate, LocalDateTime modifiedDate) {
+    private LineResponse(Long id, String name, String color, List<StationResponse> stations, LocalDateTime createdDate, LocalDateTime modifiedDate) {
         this.id = id;
         this.name = name;
         this.color = color;
@@ -26,8 +24,11 @@ public class LineResponse {
         this.modifiedDate = modifiedDate;
     }
 
-    public static LineResponse of(Line line, List<StationResponse> stations) {
-        return new LineResponse(line.getId(), line.getName(), line.getColor(), stations, line.getCreatedDate(), line.getModifiedDate());
+    public static LineResponse of(Line line) {
+        List<StationResponse> stationResponses = line.getStations().stream()
+                .map(StationResponse::of)
+                .collect(Collectors.toList());
+        return new LineResponse(line.getId(), line.getName(), line.getColor(), stationResponses, line.getCreatedDate(), line.getModifiedDate());
     }
 
     public Long getId() {

--- a/src/main/java/nextstep/subway/line/ui/LineController.java
+++ b/src/main/java/nextstep/subway/line/ui/LineController.java
@@ -1,5 +1,6 @@
 package nextstep.subway.line.ui;
 
+import nextstep.subway.line.application.LineSectionService;
 import nextstep.subway.line.application.LineService;
 import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
@@ -15,13 +16,16 @@ import java.util.List;
 @RequestMapping("/lines")
 public class LineController {
     private final LineService lineService;
+    private final LineSectionService lineSectionService;
 
-    public LineController(final LineService lineService) {
+    public LineController(final LineService lineService,
+            final LineSectionService lineSectionService) {
         this.lineService = lineService;
+        this.lineSectionService = lineSectionService;
     }
 
     @PostMapping
-    public ResponseEntity createLine(@RequestBody LineRequest lineRequest) {
+    public ResponseEntity<LineResponse> createLine(@RequestBody LineRequest lineRequest) {
         LineResponse line = lineService.saveLine(lineRequest);
         return ResponseEntity.created(URI.create("/lines/" + line.getId())).body(line);
     }
@@ -37,31 +41,31 @@ public class LineController {
     }
 
     @PutMapping("/{id}")
-    public ResponseEntity updateLine(@PathVariable Long id, @RequestBody LineRequest lineUpdateRequest) {
+    public ResponseEntity<?> updateLine(@PathVariable Long id, @RequestBody LineRequest lineUpdateRequest) {
         lineService.updateLine(id, lineUpdateRequest);
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity deleteLine(@PathVariable Long id) {
+    public ResponseEntity<?> deleteLine(@PathVariable Long id) {
         lineService.deleteLineById(id);
         return ResponseEntity.noContent().build();
     }
 
     @PostMapping("/{lineId}/sections")
-    public ResponseEntity addLineStation(@PathVariable Long lineId, @RequestBody SectionRequest sectionRequest) {
-        lineService.addLineStation(lineId, sectionRequest);
+    public ResponseEntity<?> addSection(@PathVariable Long lineId, @RequestBody SectionRequest sectionRequest) {
+        lineSectionService.addSection(lineId, sectionRequest);
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/{lineId}/sections")
-    public ResponseEntity removeLineStation(@PathVariable Long lineId, @RequestParam Long stationId) {
-        lineService.removeLineStation(lineId, stationId);
+    public ResponseEntity<?> removeSection(@PathVariable Long lineId, @RequestParam Long stationId) {
+        lineSectionService.removeSection(lineId, stationId);
         return ResponseEntity.ok().build();
     }
 
     @ExceptionHandler(DataIntegrityViolationException.class)
-    public ResponseEntity handleIllegalArgsException(DataIntegrityViolationException e) {
+    public ResponseEntity<?> handleIllegalArgsException(DataIntegrityViolationException e) {
         return ResponseEntity.badRequest().build();
     }
 }

--- a/src/main/java/nextstep/subway/station/domain/Station.java
+++ b/src/main/java/nextstep/subway/station/domain/Station.java
@@ -13,7 +13,7 @@ public class Station extends BaseEntity {
     @Column(unique = true)
     private String name;
 
-    public Station() {
+    protected Station() {
     }
 
     public Station(String name) {

--- a/src/test/java/nextstep/subway/line/acceptance/LineRestHelper.java
+++ b/src/test/java/nextstep/subway/line/acceptance/LineRestHelper.java
@@ -1,0 +1,81 @@
+package nextstep.subway.line.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.line.dto.LineRequest;
+import nextstep.subway.line.dto.LineResponse;
+import org.springframework.http.MediaType;
+
+/**
+ * @author : leesangbae
+ * @project : subway
+ * @since : 2021-01-02
+ */
+public class LineRestHelper {
+
+    public static ExtractableResponse<Response> 지하철_노선_등록되어_있음(LineRequest params) {
+        return 지하철_노선_생성_요청(params);
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_생성_요청(LineRequest params) {
+        return RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(params)
+                .when().post("/lines")
+                .then().log().all().
+                        extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_목록_조회_요청() {
+        return 지하철_노선_목록_조회_요청("/lines");
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_목록_조회_요청(ExtractableResponse<Response> response) {
+        String uri = response.header("Location");
+
+        return 지하철_노선_목록_조회_요청(uri);
+    }
+
+    private static ExtractableResponse<Response> 지하철_노선_목록_조회_요청(String uri) {
+        return RestAssured
+                .given().log().all()
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().get(uri)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_조회_요청(LineResponse response) {
+        return RestAssured
+                .given().log().all()
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/lines/{lineId}", response.getId())
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_수정_요청(ExtractableResponse<Response> response, LineRequest params) {
+        String uri = response.header("Location");
+
+        return RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(params)
+                .when().put(uri)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선_제거_요청(ExtractableResponse<Response> response) {
+        String uri = response.header("Location");
+
+        return RestAssured
+                .given().log().all()
+                .when().delete(uri)
+                .then().log().all()
+                .extract();
+    }
+
+}

--- a/src/test/java/nextstep/subway/line/acceptance/LineSectionAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/line/acceptance/LineSectionAcceptanceTest.java
@@ -1,19 +1,16 @@
 package nextstep.subway.line.acceptance;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
 import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
-import nextstep.subway.line.dto.SectionRequest;
 import nextstep.subway.station.StationAcceptanceTest;
 import nextstep.subway.station.dto.StationResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
 import java.util.Arrays;
 import java.util.List;
@@ -21,8 +18,10 @@ import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+@SuppressWarnings("NonAsciiCharacters")
 @DisplayName("지하철 구간 관련 기능")
 public class LineSectionAcceptanceTest extends AcceptanceTest {
+
     private LineResponse 신분당선;
     private StationResponse 강남역;
     private StationResponse 양재역;
@@ -39,17 +38,17 @@ public class LineSectionAcceptanceTest extends AcceptanceTest {
         광교역 = StationAcceptanceTest.지하철역_등록되어_있음("광교역").as(StationResponse.class);
 
         LineRequest lineRequest = new LineRequest("신분당선", "bg-red-600", 강남역.getId(), 광교역.getId(), 10);
-        신분당선 = LineAcceptanceTest.지하철_노선_등록되어_있음(lineRequest).as(LineResponse.class);
+        신분당선 = LineRestHelper.지하철_노선_등록되어_있음(lineRequest).as(LineResponse.class);
     }
 
     @DisplayName("지하철 구간을 등록한다.")
     @Test
     void addLineSection() {
         // when
-        지하철_노선에_지하철역_등록_요청(신분당선, 강남역, 양재역, 3);
+        LineSectionRestHelper.지하철_노선에_지하철역_등록_요청(신분당선, 강남역, 양재역, 3);
 
         // then
-        ExtractableResponse<Response> response = LineAcceptanceTest.지하철_노선_조회_요청(신분당선);
+        ExtractableResponse<Response> response = LineRestHelper.지하철_노선_조회_요청(신분당선);
         지하철_노선에_지하철역_등록됨(response);
         지하철_노선에_지하철역_순서_정렬됨(response, Arrays.asList(강남역, 양재역, 광교역));
     }
@@ -58,11 +57,11 @@ public class LineSectionAcceptanceTest extends AcceptanceTest {
     @Test
     void addLineSection2() {
         // when
-        지하철_노선에_지하철역_등록_요청(신분당선, 강남역, 양재역, 2);
-        지하철_노선에_지하철역_등록_요청(신분당선, 정자역, 강남역, 5);
+        LineSectionRestHelper.지하철_노선에_지하철역_등록_요청(신분당선, 강남역, 양재역, 2);
+        LineSectionRestHelper.지하철_노선에_지하철역_등록_요청(신분당선, 정자역, 강남역, 5);
 
         // then
-        ExtractableResponse<Response> response = LineAcceptanceTest.지하철_노선_조회_요청(신분당선);
+        ExtractableResponse<Response> response = LineRestHelper.지하철_노선_조회_요청(신분당선);
         지하철_노선에_지하철역_등록됨(response);
         지하철_노선에_지하철역_순서_정렬됨(response, Arrays.asList(정자역, 강남역, 양재역, 광교역));
     }
@@ -71,7 +70,7 @@ public class LineSectionAcceptanceTest extends AcceptanceTest {
     @Test
     void addLineSectionWithSameStation() {
         // when
-        ExtractableResponse<Response> response = 지하철_노선에_지하철역_등록_요청(신분당선, 강남역, 광교역, 3);
+        ExtractableResponse<Response> response = LineSectionRestHelper.지하철_노선에_지하철역_등록_요청(신분당선, 강남역, 광교역, 3);
 
         // then
         지하철_노선에_지하철역_등록_실패됨(response);
@@ -81,7 +80,7 @@ public class LineSectionAcceptanceTest extends AcceptanceTest {
     @Test
     void addLineSectionWithNoStation() {
         // when
-        ExtractableResponse<Response> response = 지하철_노선에_지하철역_등록_요청(신분당선, 정자역, 양재역, 3);
+        ExtractableResponse<Response> response = LineSectionRestHelper.지하철_노선에_지하철역_등록_요청(신분당선, 정자역, 양재역, 3);
 
         // then
         지하철_노선에_지하철역_등록_실패됨(response);
@@ -91,15 +90,15 @@ public class LineSectionAcceptanceTest extends AcceptanceTest {
     @Test
     void removeLineSection1() {
         // given
-        지하철_노선에_지하철역_등록_요청(신분당선, 강남역, 양재역, 2);
-        지하철_노선에_지하철역_등록_요청(신분당선, 양재역, 정자역, 2);
+        LineSectionRestHelper.지하철_노선에_지하철역_등록_요청(신분당선, 강남역, 양재역, 2);
+        LineSectionRestHelper.지하철_노선에_지하철역_등록_요청(신분당선, 양재역, 정자역, 2);
 
         // when
-        ExtractableResponse<Response> removeResponse = 지하철_노선에_지하철역_제외_요청(신분당선, 양재역);
+        ExtractableResponse<Response> removeResponse = LineSectionRestHelper.지하철_노선에_지하철역_제외_요청(신분당선, 양재역);
 
         // then
         지하철_노선에_지하철역_제외됨(removeResponse);
-        ExtractableResponse<Response> response = LineAcceptanceTest.지하철_노선_조회_요청(신분당선);
+        ExtractableResponse<Response> response = LineRestHelper.지하철_노선_조회_요청(신분당선);
         지하철_노선에_지하철역_순서_정렬됨(response, Arrays.asList(강남역, 정자역, 광교역));
     }
 
@@ -107,23 +106,12 @@ public class LineSectionAcceptanceTest extends AcceptanceTest {
     @Test
     void removeLineSection2() {
         // when
-        ExtractableResponse<Response> removeResponse = 지하철_노선에_지하철역_제외_요청(신분당선, 강남역);
+        ExtractableResponse<Response> removeResponse = LineSectionRestHelper.지하철_노선에_지하철역_제외_요청(신분당선, 강남역);
 
         // then
         지하철_노선에_지하철역_제외_실패됨(removeResponse);
     }
 
-    public static ExtractableResponse<Response> 지하철_노선에_지하철역_등록_요청(LineResponse line, StationResponse upStation, StationResponse downStation, int distance) {
-        SectionRequest sectionRequest = new SectionRequest(upStation.getId(), downStation.getId(), distance);
-
-        return RestAssured
-                .given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(sectionRequest)
-                .when().post("/lines/{lineId}/sections", line.getId())
-                .then().log().all()
-                .extract();
-    }
 
     public static void 지하철_노선에_지하철역_등록됨(ExtractableResponse<Response> response) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
@@ -136,22 +124,14 @@ public class LineSectionAcceptanceTest extends AcceptanceTest {
     public static void 지하철_노선에_지하철역_순서_정렬됨(ExtractableResponse<Response> response, List<StationResponse> expectedStations) {
         LineResponse line = response.as(LineResponse.class);
         List<Long> stationIds = line.getStations().stream()
-                .map(it -> it.getId())
+                .map(StationResponse::getId)
                 .collect(Collectors.toList());
 
         List<Long> expectedStationIds = expectedStations.stream()
-                .map(it -> it.getId())
+                .map(StationResponse::getId)
                 .collect(Collectors.toList());
 
         assertThat(stationIds).containsExactlyElementsOf(expectedStationIds);
-    }
-
-    public static ExtractableResponse<Response> 지하철_노선에_지하철역_제외_요청(LineResponse line, StationResponse station) {
-        return RestAssured
-                .given().log().all()
-                .when().delete("/lines/{lineId}/sections?stationId={stationId}", line.getId(), station.getId())
-                .then().log().all()
-                .extract();
     }
 
     public static void 지하철_노선에_지하철역_제외됨(ExtractableResponse<Response> response) {

--- a/src/test/java/nextstep/subway/line/acceptance/LineSectionRestHelper.java
+++ b/src/test/java/nextstep/subway/line/acceptance/LineSectionRestHelper.java
@@ -1,0 +1,39 @@
+package nextstep.subway.line.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.line.dto.LineResponse;
+import nextstep.subway.line.dto.SectionRequest;
+import nextstep.subway.station.dto.StationResponse;
+import org.springframework.http.MediaType;
+
+/**
+ * @author : leesangbae
+ * @project : subway
+ * @since : 2021-01-02
+ */
+public class LineSectionRestHelper {
+
+    public static ExtractableResponse<Response> 지하철_노선에_지하철역_등록_요청(LineResponse line, StationResponse upStation, StationResponse downStation, int distance) {
+        SectionRequest sectionRequest = new SectionRequest(upStation.getId(), downStation.getId(), distance);
+
+        return RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(sectionRequest)
+                .when().post("/lines/{lineId}/sections", line.getId())
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선에_지하철역_제외_요청(LineResponse line, StationResponse station) {
+        return RestAssured
+                .given().log().all()
+                .when().delete("/lines/{lineId}/sections?stationId={stationId}", line.getId(), station.getId())
+                .then().log().all()
+                .extract();
+    }
+
+
+}

--- a/src/test/java/nextstep/subway/line/domain/SectionsTest.java
+++ b/src/test/java/nextstep/subway/line/domain/SectionsTest.java
@@ -1,0 +1,97 @@
+package nextstep.subway.line.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import nextstep.subway.station.domain.Station;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+/**
+ * @author : leesangbae
+ * @project : subway
+ * @since : 2021-01-02
+ */
+@SuppressWarnings("NonAsciiCharacters")
+@DisplayName("Sesions 일급 객체 Test Class")
+class SectionsTest {
+
+    private Sections sections;
+
+    private Line line = new Line("2호선", "yellow");
+    private Station 강남역 = new Station("강남역");
+    private Station 사당역 = new Station("사당역");
+
+    @BeforeEach
+    void setup() {
+        sections = new Sections();
+    }
+
+    @DisplayName("Section 추가 Test")
+    @Test
+    void addSectionTest() {
+        Section section = new Section(line, 강남역, 사당역, 10);
+
+        sections.add(section);
+        List<Station> stations = sections.getStations();
+
+        assertThat(stations).isNotEmpty();
+        assertThat(stations.size()).isEqualTo(2);
+        assertThat(stations.get(0).getName()).isEqualTo("강남역");
+        assertThat(stations.get(1).getName()).isEqualTo("사당역");
+    }
+
+    @DisplayName("Section 중복 추가 Test")
+    @Test
+    void addDuplicateSectionTest() {
+        Section section = new Section(line, 강남역, 사당역, 10);
+
+        sections.add(section);
+
+        assertThatThrownBy(() -> sections.add(section))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("이미 등록된 구간 입니다.");
+    }
+
+    @DisplayName("Line에 추가되지 않은 역의 Section 추가 Test")
+    @Test
+    void addNotContainsSectionTest() {
+        Section section = new Section(line, 강남역, 사당역, 10);
+
+        sections.add(section);
+        Station 양재역 = new Station("양재역");
+        Station 판교역 = new Station("판교역");
+        Section notContainsSection = new Section(line, 양재역, 판교역, 10);
+
+        assertThatThrownBy(() -> sections.add(notContainsSection))
+                .isInstanceOf(RuntimeException.class)
+                .hasMessageContaining("등록할 수 없는 구간 입니다.");
+    }
+
+    @DisplayName("Section 삭제 Test")
+    @Test
+    void removeSectionTest() {
+        Station 양재역 = new Station("양재역");
+        Section section01 = new Section(line, 강남역, 사당역, 10);
+        Section section02 = new Section(line, 사당역, 양재역, 10);
+
+        sections.add(section01);
+        sections.add(section02);
+
+        sections.remove(line, 사당역);
+
+        List<Station> stations = sections.getStations();
+        assertThat(stations.size()).isEqualTo(2);
+        assertThat(stations.get(0).getName()).isEqualTo("강남역");
+    }
+
+    @DisplayName("비어있는 Sections에 삭제 Test")
+    @Test
+    void removeEmptySectionsTest() {
+        assertThatThrownBy(() -> sections.remove(line, 강남역))
+                .isInstanceOf(RuntimeException.class);
+    }
+
+}

--- a/src/test/java/study/unit/MockitoExtensionTest.java
+++ b/src/test/java/study/unit/MockitoExtensionTest.java
@@ -29,7 +29,7 @@ public class MockitoExtensionTest {
     @Test
     void findAllLines() {
         // given
-        when(lineRepository.findAll()).thenReturn(Lists.newArrayList(new Line()));
+        when(lineRepository.findAll()).thenReturn(Lists.newArrayList(new Line("2호선", "green")));
         LineService lineService = new LineService(lineRepository, stationService);
 
         // when

--- a/src/test/java/study/unit/MockitoTest.java
+++ b/src/test/java/study/unit/MockitoTest.java
@@ -24,7 +24,7 @@ public class MockitoTest {
         LineRepository lineRepository = mock(LineRepository.class);
         StationService stationService = mock(StationService.class);
 
-        when(lineRepository.findAll()).thenReturn(Lists.newArrayList(new Line()));
+        when(lineRepository.findAll()).thenReturn(Lists.newArrayList(new Line("2호선", "green")));
         LineService lineService = new LineService(lineRepository, stationService);
 
         // when

--- a/src/test/java/study/unit/SpringExtensionTest.java
+++ b/src/test/java/study/unit/SpringExtensionTest.java
@@ -28,7 +28,7 @@ public class SpringExtensionTest {
     @Test
     void findAllLines() {
         // given
-        when(lineRepository.findAll()).thenReturn(Lists.newArrayList(new Line()));
+        when(lineRepository.findAll()).thenReturn(Lists.newArrayList(new Line("2호선", "green")));
         LineService lineService = new LineService(lineRepository, stationService);
 
         // when


### PR DESCRIPTION
안녕하세요 이번 `인수 테스트 기반 TDD` 과제를 진행하게 된 이상배입니다.
매일매일 쏟아지는 리뷰 요청 처리하시느라 수고가 많으십니다.

이번 구현에서 중요한 사항은 다음과 같습니다.
- Service에서 도메인 로직은 일급객체로 분리.
- 중복으로 사용되었던 코드들 한곳으로 응집

그리고 질문이 있습니다.
지금 과제가 소규모라 따로 구현하진 않았는데 구현중에 고민인 사항이 있었습니다.
일급 컬렉션이 현재 다른 도메인 객체들에 비해 비대해지는 사항이 발생하는거 같아 `Domain Service`를 생성해서 로직을 분리할까 생각을 해봤었습니다.
일급 컬렉션은 저장/삭제만 진행하고 그 이전에 validation이나 merge 하는 로직이같은걸 서비스로 뺴는것도 좋은 방법일까요?
[`Controller` -> `Application Service`] -> [`Domain Service` -> `Domain`]  형식으로 생각은 해봤는데
생성과 삭제의 책임은 일급 컬렉션이 가져가는게 아무래도 자연스러울거 같아서 일급컬렉션에 위임해둔 상태입니다.
해당 궁금증에 짧은 의견하나만 달아주시면 감사하겠습니다.

새해복 많이받으시고 코드에 많은 지적 부탁드립니다.
감사합니다.