### PR TITLE
Step3

### DIFF
--- a/src/main/java/nextstep/subway/auth/application/AuthService.java
+++ b/src/main/java/nextstep/subway/auth/application/AuthService.java
@@ -33,7 +33,7 @@ public class AuthService {
         }
 
         String email = jwtTokenProvider.getPayload(credentials);
-        Member member = memberRepository.findByEmail(email).orElseThrow(RuntimeException::new);
+        Member member = memberRepository.findByEmail(email).orElseThrow(AuthorizationException::new);
         return new LoginMember(member.getId(), member.getEmail(), member.getAge());
     }
 }

--- a/src/main/java/nextstep/subway/auth/application/AuthService.java
+++ b/src/main/java/nextstep/subway/auth/application/AuthService.java
@@ -29,7 +29,7 @@ public class AuthService {
 
     public LoginMember findMemberByToken(String credentials) {
         if (!jwtTokenProvider.validateToken(credentials)) {
-            return new LoginMember();
+            throw new AuthorizationException("cannot find token matched member");
         }
 
         String email = jwtTokenProvider.getPayload(credentials);

--- a/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
+++ b/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
@@ -1,35 +1,87 @@
 package nextstep.subway.favorite.application;
 
+import nextstep.subway.auth.application.AuthorizationException;
 import nextstep.subway.auth.domain.LoginMember;
+import nextstep.subway.favorite.domain.Favorite;
 import nextstep.subway.favorite.domain.FavoriteRepository;
 import nextstep.subway.favorite.dto.FavoriteRequest;
 import nextstep.subway.favorite.dto.FavoriteResponse;
+import nextstep.subway.member.domain.Member;
 import nextstep.subway.member.domain.MemberRepository;
+import nextstep.subway.station.domain.Station;
+import nextstep.subway.station.domain.StationRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 public class FavoriteService {
+	private static final String EXCEPTION_NOT_EXIST_FAVORITE = "존재하지 않는 즐겨찾기입니다.";
+	private static final String EXCEPTION_NOT_EXIST_STATION = "존재하지 않는 역을 즐겨찾기로 추가할 수 없습니다.";
+	private static final String EXCEPTION_SAME_STATION = "출발역 도착역이 같아 등록이 불가능합니다.";
+	private static final String EXCEPTION_ALREADY_EXIST = "출발역 도착역이 같은 즐겨찾기가 이미 등록되어 있습니다.";
 	private final FavoriteRepository favoriteRepository;
+	private final StationRepository stationRepository;
 	private final MemberRepository memberRepository;
 
-	public FavoriteService(FavoriteRepository favoriteRepository, MemberRepository memberRepository) {
+	public FavoriteService(FavoriteRepository favoriteRepository, StationRepository stationRepository, MemberRepository memberRepository) {
 		this.favoriteRepository = favoriteRepository;
+		this.stationRepository = stationRepository;
 		this.memberRepository = memberRepository;
 	}
 
 	public List<FavoriteResponse> getFavorites(LoginMember loginMember) {
-
+		List<Favorite> favorites = favoriteRepository.findAllByMember_Id(loginMember.getId());
+		return favorites.stream()
+				.map(FavoriteResponse::of)
+				.collect(Collectors.toList());
 	}
 
+	@Transactional
 	public FavoriteResponse createFavorite(LoginMember loginMember, FavoriteRequest favoriteRequest) {
-
+		validateCreateFavorite(loginMember, favoriteRequest);
+		Favorite favorite = favoriteRepository.save(createNewEntity(loginMember, favoriteRequest));
+		return FavoriteResponse.of(favorite);
 	}
 
-	public void deleteFavoriteById(LoginMember loginMember, Long favoriteId) {
+	private void validateCreateFavorite(LoginMember loginMember, FavoriteRequest favoriteRequest) {
+		if (Objects.equals(favoriteRequest.getSource(), favoriteRequest.getTarget())) {
+			throw new FavoriteValidationException(EXCEPTION_SAME_STATION);
+		}
 
+		final boolean alreadyExist = favoriteRepository.existsFavoriteByMember_IdAndSource_IdAndTarget_Id(
+				loginMember.getId(), favoriteRequest.getSource(), favoriteRequest.getTarget());
+		if (alreadyExist) {
+			throw new FavoriteValidationException(EXCEPTION_ALREADY_EXIST);
+		}
+	}
+
+	private Favorite createNewEntity(LoginMember loginMember, FavoriteRequest favoriteRequest) {
+		Member member = memberRepository.findById(loginMember.getId())
+				.orElseThrow(() -> new AuthorizationException("만료된 ID 입니다."));
+
+		List<Station> findResult = stationRepository.findAllByIdIn(
+				Arrays.asList(favoriteRequest.getSource(), favoriteRequest.getTarget()));
+		Station source = findResult.stream()
+				.filter(station -> station.getId().equals(favoriteRequest.getSource()))
+				.findFirst()
+				.orElseThrow(() -> new FavoriteValidationException(EXCEPTION_NOT_EXIST_STATION));
+		Station target = findResult.stream()
+				.filter(station -> station.getId().equals(favoriteRequest.getTarget()))
+				.findFirst()
+				.orElseThrow(() -> new FavoriteValidationException(EXCEPTION_NOT_EXIST_STATION));
+		return new Favorite(member, source, target);
+	}
+
+	@Transactional
+	public void deleteFavoriteById(LoginMember loginMember, Long favoriteId) {
+		Favorite favorite = favoriteRepository.findByIdAndMember_Id(favoriteId, loginMember.getId())
+				.orElseThrow(() -> new FavoriteValidationException(EXCEPTION_NOT_EXIST_FAVORITE));
+		favoriteRepository.delete(favorite);
 	}
 }

--- a/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
+++ b/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
@@ -1,0 +1,35 @@
+package nextstep.subway.favorite.application;
+
+import nextstep.subway.auth.domain.LoginMember;
+import nextstep.subway.favorite.domain.FavoriteRepository;
+import nextstep.subway.favorite.dto.FavoriteRequest;
+import nextstep.subway.favorite.dto.FavoriteResponse;
+import nextstep.subway.member.domain.MemberRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@Transactional
+public class FavoriteService {
+	private final FavoriteRepository favoriteRepository;
+	private final MemberRepository memberRepository;
+
+	public FavoriteService(FavoriteRepository favoriteRepository, MemberRepository memberRepository) {
+		this.favoriteRepository = favoriteRepository;
+		this.memberRepository = memberRepository;
+	}
+
+	public List<FavoriteResponse> getFavorites(LoginMember loginMember) {
+
+	}
+
+	public FavoriteResponse createFavorite(LoginMember loginMember, FavoriteRequest favoriteRequest) {
+
+	}
+
+	public void deleteFavoriteById(LoginMember loginMember, Long favoriteId) {
+
+	}
+}

--- a/src/main/java/nextstep/subway/favorite/application/FavoriteValidationException.java
+++ b/src/main/java/nextstep/subway/favorite/application/FavoriteValidationException.java
@@ -1,0 +1,22 @@
+package nextstep.subway.favorite.application;
+
+public class FavoriteValidationException extends RuntimeException {
+	public FavoriteValidationException() {
+	}
+
+	public FavoriteValidationException(String message) {
+		super(message);
+	}
+
+	public FavoriteValidationException(String message, Throwable cause) {
+		super(message, cause);
+	}
+
+	public FavoriteValidationException(Throwable cause) {
+		super(cause);
+	}
+
+	public FavoriteValidationException(String message, Throwable cause, boolean enableSuppression, boolean writableStackTrace) {
+		super(message, cause, enableSuppression, writableStackTrace);
+	}
+}

--- a/src/main/java/nextstep/subway/favorite/domain/Favorite.java
+++ b/src/main/java/nextstep/subway/favorite/domain/Favorite.java
@@ -1,0 +1,52 @@
+package nextstep.subway.favorite.domain;
+
+import nextstep.subway.BaseEntity;
+import nextstep.subway.member.domain.Member;
+import nextstep.subway.station.domain.Station;
+
+import javax.persistence.*;
+
+@Entity
+public class Favorite extends BaseEntity {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne
+	@JoinColumn(name = "member_id", nullable = false)
+	private Member member;
+
+	@ManyToOne
+	@JoinColumn(name = "source_id", nullable = false)
+	private Station source;
+
+	@ManyToOne
+	@JoinColumn(name = "target_id", nullable = false)
+	private Station target;
+
+	public Favorite() {
+	}
+
+	public Favorite(Member member, Station source, Station target) {
+		this.member = member;
+		this.source = source;
+		this.target = target;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public Member getMember() {
+		return member;
+	}
+
+	public Station getSource() {
+		return source;
+	}
+
+	public Station getTarget() {
+		return target;
+	}
+}

--- a/src/main/java/nextstep/subway/favorite/domain/FavoriteRepository.java
+++ b/src/main/java/nextstep/subway/favorite/domain/FavoriteRepository.java
@@ -1,0 +1,12 @@
+package nextstep.subway.favorite.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+	List<Favorite> findAllByMember_Id(Long id);
+	Optional<Favorite> findByIdAndMember_Id(Long id, Long memberId);
+	boolean existsFavoriteByMember_IdAndSource_IdAndTarget_Id(Long memberId, Long sourceId, Long targetId);
+}

--- a/src/main/java/nextstep/subway/favorite/dto/FavoriteRequest.java
+++ b/src/main/java/nextstep/subway/favorite/dto/FavoriteRequest.java
@@ -1,0 +1,22 @@
+package nextstep.subway.favorite.dto;
+
+public class FavoriteRequest {
+	private Long source;
+	private Long target;
+
+	public FavoriteRequest() {
+	}
+
+	public FavoriteRequest(Long source, Long target) {
+		this.source = source;
+		this.target = target;
+	}
+
+	public Long getSource() {
+		return source;
+	}
+
+	public Long getTarget() {
+		return target;
+	}
+}

--- a/src/main/java/nextstep/subway/favorite/dto/FavoriteResponse.java
+++ b/src/main/java/nextstep/subway/favorite/dto/FavoriteResponse.java
@@ -1,5 +1,6 @@
 package nextstep.subway.favorite.dto;
 
+import nextstep.subway.favorite.domain.Favorite;
 import nextstep.subway.station.dto.StationResponse;
 
 public class FavoriteResponse {
@@ -8,6 +9,18 @@ public class FavoriteResponse {
 	private StationResponse target;
 
 	public FavoriteResponse() {
+	}
+
+	public static FavoriteResponse of(Favorite favorite) {
+		StationResponse source = StationResponse.of(favorite.getSource());
+		StationResponse target = StationResponse.of(favorite.getTarget());
+		return new FavoriteResponse(favorite.getId(), source, target);
+	}
+
+	private FavoriteResponse(Long id, StationResponse source, StationResponse target) {
+		this.id = id;
+		this.source = source;
+		this.target = target;
 	}
 
 	public Long getId() {

--- a/src/main/java/nextstep/subway/favorite/dto/FavoriteResponse.java
+++ b/src/main/java/nextstep/subway/favorite/dto/FavoriteResponse.java
@@ -1,0 +1,24 @@
+package nextstep.subway.favorite.dto;
+
+import nextstep.subway.station.dto.StationResponse;
+
+public class FavoriteResponse {
+	private Long id;
+	private StationResponse source;
+	private StationResponse target;
+
+	public FavoriteResponse() {
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public StationResponse getSource() {
+		return source;
+	}
+
+	public StationResponse getTarget() {
+		return target;
+	}
+}

--- a/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
+++ b/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
@@ -1,35 +1,61 @@
 package nextstep.subway.favorite.ui;
 
+import nextstep.subway.auth.application.AuthorizationException;
 import nextstep.subway.auth.domain.AuthenticationPrincipal;
 import nextstep.subway.auth.domain.LoginMember;
+import nextstep.subway.favorite.application.FavoriteService;
+import nextstep.subway.favorite.application.FavoriteValidationException;
 import nextstep.subway.favorite.dto.FavoriteRequest;
 import nextstep.subway.favorite.dto.FavoriteResponse;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import java.net.URI;
-import java.util.Collections;
 import java.util.List;
 
 @RestController
 @RequestMapping("/favorites")
 public class FavoriteController {
 
+	private final FavoriteService favoriteService;
+
+	public FavoriteController(FavoriteService favoriteService) {
+		this.favoriteService = favoriteService;
+	}
+
 	@GetMapping
 	public ResponseEntity<List<FavoriteResponse>> getFavorites(@AuthenticationPrincipal LoginMember loginMember) {
-		return ResponseEntity.ok(Collections.emptyList());
+		return ResponseEntity.ok(favoriteService.getFavorites(loginMember));
 	}
 
 	@PostMapping
 	public ResponseEntity postFavorites(@AuthenticationPrincipal LoginMember loginMember,
 	                                    @RequestBody FavoriteRequest favoriteRequest) {
-		FavoriteResponse favoriteResponse = new FavoriteResponse();
-		return ResponseEntity.created(URI.create("/favorites/" + 1)).build();
+		FavoriteResponse favoriteResponse = favoriteService.createFavorite(loginMember, favoriteRequest);
+		return ResponseEntity.created(URI.create("/favorites/" + favoriteResponse.getId())).build();
 	}
 
 	@DeleteMapping(value = "/{id}")
 	public ResponseEntity deleteFavorite(@AuthenticationPrincipal LoginMember loginMember,
 	                                     @PathVariable(value = "id") Long favoriteId) {
+		favoriteService.deleteFavoriteById(loginMember, favoriteId);
 		return ResponseEntity.noContent().build();
 	}
+
+	@ExceptionHandler(RuntimeException.class)
+	public ResponseEntity handleRuntimeException(RuntimeException e) {
+		return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR).build();
+	}
+
+	@ExceptionHandler(FavoriteValidationException.class)
+	public ResponseEntity handleFavoriteValidationException(FavoriteValidationException e) {
+		return ResponseEntity.badRequest().build();
+	}
+
+	@ExceptionHandler(AuthorizationException.class)
+	public ResponseEntity handleFavoriteAuthorizationException(AuthorizationException e) {
+		return ResponseEntity.status(HttpStatus.UNAUTHORIZED).build();
+	}
+
 }

--- a/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
+++ b/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
@@ -1,0 +1,35 @@
+package nextstep.subway.favorite.ui;
+
+import nextstep.subway.auth.domain.AuthenticationPrincipal;
+import nextstep.subway.auth.domain.LoginMember;
+import nextstep.subway.favorite.dto.FavoriteRequest;
+import nextstep.subway.favorite.dto.FavoriteResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+
+@RestController
+@RequestMapping("/favorites")
+public class FavoriteController {
+
+	@GetMapping
+	public ResponseEntity<List<FavoriteResponse>> getFavorites(@AuthenticationPrincipal LoginMember loginMember) {
+		return ResponseEntity.ok(Collections.emptyList());
+	}
+
+	@PostMapping
+	public ResponseEntity postFavorites(@AuthenticationPrincipal LoginMember loginMember,
+	                                    @RequestBody FavoriteRequest favoriteRequest) {
+		FavoriteResponse favoriteResponse = new FavoriteResponse();
+		return ResponseEntity.created(URI.create("/favorites/" + 1)).build();
+	}
+
+	@DeleteMapping(value = "/{id}")
+	public ResponseEntity deleteFavorite(@AuthenticationPrincipal LoginMember loginMember,
+	                                     @PathVariable(value = "id") Long favoriteId) {
+		return ResponseEntity.noContent().build();
+	}
+}

--- a/src/main/java/nextstep/subway/member/application/MemberService.java
+++ b/src/main/java/nextstep/subway/member/application/MemberService.java
@@ -11,6 +11,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @Transactional
 public class MemberService {
+    private static final String EXCEPTION_CANNOT_FIND_MEMBER = "cannot find id matched member";
     private MemberRepository memberRepository;
 
     public MemberService(MemberRepository memberRepository) {
@@ -23,12 +24,12 @@ public class MemberService {
     }
 
     public MemberResponse findMember(Long id) {
-        Member member = memberRepository.findById(id).orElseThrow(AuthorizationException::new);
+        Member member = memberRepository.findById(id).orElseThrow(() -> new AuthorizationException(EXCEPTION_CANNOT_FIND_MEMBER));
         return MemberResponse.of(member);
     }
 
     public void updateMember(Long id, MemberRequest param) {
-        Member member = memberRepository.findById(id).orElseThrow(AuthorizationException::new);
+        Member member = memberRepository.findById(id).orElseThrow(() -> new AuthorizationException(EXCEPTION_CANNOT_FIND_MEMBER));
         member.update(param.toMember());
     }
 

--- a/src/main/java/nextstep/subway/member/application/MemberService.java
+++ b/src/main/java/nextstep/subway/member/application/MemberService.java
@@ -1,5 +1,6 @@
 package nextstep.subway.member.application;
 
+import nextstep.subway.auth.application.AuthorizationException;
 import nextstep.subway.member.domain.Member;
 import nextstep.subway.member.domain.MemberRepository;
 import nextstep.subway.member.dto.MemberRequest;
@@ -8,6 +9,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
+@Transactional
 public class MemberService {
     private MemberRepository memberRepository;
 
@@ -21,12 +23,12 @@ public class MemberService {
     }
 
     public MemberResponse findMember(Long id) {
-        Member member = memberRepository.findById(id).orElseThrow(RuntimeException::new);
+        Member member = memberRepository.findById(id).orElseThrow(AuthorizationException::new);
         return MemberResponse.of(member);
     }
 
     public void updateMember(Long id, MemberRequest param) {
-        Member member = memberRepository.findById(id).orElseThrow(RuntimeException::new);
+        Member member = memberRepository.findById(id).orElseThrow(AuthorizationException::new);
         member.update(param.toMember());
     }
 

--- a/src/main/java/nextstep/subway/member/ui/MemberController.java
+++ b/src/main/java/nextstep/subway/member/ui/MemberController.java
@@ -2,7 +2,6 @@ package nextstep.subway.member.ui;
 
 import nextstep.subway.auth.domain.LoginMember;
 import nextstep.subway.auth.domain.AuthenticationPrincipal;
-import nextstep.subway.auth.domain.LoginMember;
 import nextstep.subway.member.application.MemberService;
 import nextstep.subway.member.dto.MemberRequest;
 import nextstep.subway.member.dto.MemberResponse;
@@ -44,19 +43,19 @@ public class MemberController {
     }
 
     @GetMapping("/members/me")
-    public ResponseEntity<MemberResponse> findMemberOfMine(LoginMember loginMember) {
+    public ResponseEntity<MemberResponse> findMemberOfMine(@AuthenticationPrincipal LoginMember loginMember) {
         MemberResponse member = memberService.findMember(loginMember.getId());
         return ResponseEntity.ok().body(member);
     }
 
     @PutMapping("/members/me")
-    public ResponseEntity<MemberResponse> updateMemberOfMine(LoginMember loginMember, @RequestBody MemberRequest param) {
+    public ResponseEntity<MemberResponse> updateMemberOfMine(@AuthenticationPrincipal LoginMember loginMember, @RequestBody MemberRequest param) {
         memberService.updateMember(loginMember.getId(), param);
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/members/me")
-    public ResponseEntity<MemberResponse> deleteMemberOfMine(LoginMember loginMember) {
+    public ResponseEntity<MemberResponse> deleteMemberOfMine(@AuthenticationPrincipal LoginMember loginMember) {
         memberService.deleteMember(loginMember.getId());
         return ResponseEntity.noContent().build();
     }

--- a/src/test/java/nextstep/subway/auth/acceptance/AuthAcceptanceSupport.java
+++ b/src/test/java/nextstep/subway/auth/acceptance/AuthAcceptanceSupport.java
@@ -1,0 +1,62 @@
+package nextstep.subway.auth.acceptance;
+
+import io.restassured.RestAssured;
+import io.restassured.http.Header;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.auth.dto.TokenRequest;
+import nextstep.subway.member.dto.MemberRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AuthAcceptanceSupport {
+
+	public static ExtractableResponse<Response> 회원_가입_되어있음(String email, String password) {
+		return RestAssured
+				.given().log().all()
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.body(new MemberRequest(email, password, 30))
+				.when().post("/members")
+				.then().log().all().
+						extract();
+	}
+
+	public static ExtractableResponse<Response> 회원_로그인_요청(String email, String password) {
+		return RestAssured
+				.given().log().all()
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.body(new TokenRequest(email, password))
+				.when().post("/login/token")
+				.then().log().all().
+						extract();
+	}
+
+	public static void 로그인_성공함(ExtractableResponse<Response> response) {
+		assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+		assertThat(response.body().jsonPath().getString("accessToken")).isNotNull();
+	}
+
+	public static void 로그인_실패함(ExtractableResponse<Response> response) {
+		assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+	}
+
+	public static ExtractableResponse<Response> 회원기능_요청(String token) {
+		return RestAssured
+				.given().log().all()
+				.header(createTokenHeader(token))
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.when().get("/members/me")
+				.then().log().all().
+						extract();
+	}
+
+	private static Header createTokenHeader(String token) {
+		return new Header("authorization", String.format("Bearer %s", token));
+	}
+
+	public static void 인증_실패함(ExtractableResponse<Response> response) {
+		assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+	}
+}

--- a/src/test/java/nextstep/subway/auth/acceptance/AuthAcceptanceSupport.java
+++ b/src/test/java/nextstep/subway/auth/acceptance/AuthAcceptanceSupport.java
@@ -1,10 +1,10 @@
 package nextstep.subway.auth.acceptance;
 
 import io.restassured.RestAssured;
-import io.restassured.http.Header;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.auth.dto.TokenRequest;
+import nextstep.subway.member.MemberAcceptanceSupport;
 import nextstep.subway.member.dto.MemberRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -42,18 +42,8 @@ public class AuthAcceptanceSupport {
 		assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
 	}
 
-	public static ExtractableResponse<Response> 회원기능_요청(String token) {
-		return RestAssured
-				.given().log().all()
-				.header(createTokenHeader(token))
-				.contentType(MediaType.APPLICATION_JSON_VALUE)
-				.when().get("/members/me")
-				.then().log().all().
-						extract();
-	}
-
-	private static Header createTokenHeader(String token) {
-		return new Header("authorization", String.format("Bearer %s", token));
+	public static ExtractableResponse<Response> 회원기능_요청(String accessToken) {
+		return MemberAcceptanceSupport.내_정보_조회_요청(accessToken);
 	}
 
 	public static void 인증_실패함(ExtractableResponse<Response> response) {

--- a/src/test/java/nextstep/subway/auth/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/auth/acceptance/AuthAcceptanceTest.java
@@ -1,24 +1,39 @@
 package nextstep.subway.auth.acceptance;
 
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
-public class AuthAcceptanceTest extends AcceptanceTest {
+@SuppressWarnings("NonAsciiCharacters")
+class AuthAcceptanceTest extends AcceptanceTest {
 
     @DisplayName("Bearer Auth")
     @Test
     void myInfoWithBearerAuth() {
+        final String s = "email@gmail.com";
+        final String password = "password";
+        AuthAcceptanceSupport.회원_가입_되어있음(s, password);
+
+        ExtractableResponse<Response> 로그인_요청_결과 = AuthAcceptanceSupport.회원_로그인_요청(s, password);
+
+        AuthAcceptanceSupport.로그인_성공함(로그인_요청_결과);
     }
 
     @DisplayName("Bearer Auth 로그인 실패")
     @Test
     void myInfoWithBadBearerAuth() {
+        ExtractableResponse<Response> 로그인_요청_결과 = AuthAcceptanceSupport.회원_로그인_요청("any@gmail.com", "1234");
+
+        AuthAcceptanceSupport.로그인_실패함(로그인_요청_결과);
     }
 
     @DisplayName("Bearer Auth 유효하지 않은 토큰")
     @Test
     void myInfoWithWrongBearerAuth() {
-    }
+        ExtractableResponse<Response> 회원기능_요청 = AuthAcceptanceSupport.회원기능_요청("token");
 
+        AuthAcceptanceSupport.인증_실패함(회원기능_요청);
+    }
 }

--- a/src/test/java/nextstep/subway/favorite/FavoriteAcceptanceSupport.java
+++ b/src/test/java/nextstep/subway/favorite/FavoriteAcceptanceSupport.java
@@ -41,11 +41,11 @@ public class FavoriteAcceptanceSupport {
 	public static void 즐겨찾기_목록_검사(ExtractableResponse<Response> 즐겨찾기_목록_조회_결과, int size, List<String> sourceStationNames) {
 		List<FavoriteResponse> favoriteResponses =
 				즐겨찾기_목록_조회_결과.body().jsonPath().getList("", FavoriteResponse.class);
-//		assertThat(favoriteResponses)
-//				.hasSize(size)
-//				.map(favoriteResponse -> favoriteResponse.getSource().getName())
-//				.asList()
-//				.containsExactly(sourceStationNames);
+		assertThat(favoriteResponses)
+				.hasSize(size)
+				.map(favoriteResponse -> favoriteResponse.getSource().getName())
+				.asList()
+				.containsExactly(sourceStationNames.toArray());
 	}
 
 	public static ExtractableResponse<Response> 즐겨찾기_삭제_요청(String accessToken, ExtractableResponse<Response> 즐겨찾기_생성_결과) {
@@ -60,5 +60,9 @@ public class FavoriteAcceptanceSupport {
 
 	public static void 즐겨찾기_삭제됨(ExtractableResponse<Response> 즐겨찾기_삭제_결과) {
 		assertThat(즐겨찾기_삭제_결과.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+	}
+
+	public static void 즐겨찾기_삭제_실패함(ExtractableResponse<Response> 즐겨찾기_삭제_결과) {
+		assertThat(즐겨찾기_삭제_결과.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
 	}
 }

--- a/src/test/java/nextstep/subway/favorite/FavoriteAcceptanceSupport.java
+++ b/src/test/java/nextstep/subway/favorite/FavoriteAcceptanceSupport.java
@@ -1,0 +1,64 @@
+package nextstep.subway.favorite;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.favorite.dto.FavoriteRequest;
+import nextstep.subway.favorite.dto.FavoriteResponse;
+import nextstep.subway.station.dto.StationResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class FavoriteAcceptanceSupport {
+	public static ExtractableResponse<Response> 즐겨찾기_생성_요청(String accessToken, StationResponse source, StationResponse target) {
+		FavoriteRequest favoriteRequest = new FavoriteRequest(source.getId(), target.getId());
+		return RestAssured
+				.given().log().all().auth().oauth2(accessToken)
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.body(favoriteRequest)
+				.when().post("/favorites")
+				.then().log().all()
+				.extract();
+	}
+
+	public static void 즐겨찾기_생성됨(ExtractableResponse<Response> 즐겨찾기_생성_결과) {
+		assertThat(즐겨찾기_생성_결과.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+	}
+
+	public static ExtractableResponse<Response> 즐겨찾기_목록_조회_요청(String accessToken) {
+		return RestAssured
+				.given().log().all().auth().oauth2(accessToken)
+				.accept(MediaType.APPLICATION_JSON_VALUE)
+				.when().get("/favorites")
+				.then().log().all()
+				.extract();
+	}
+
+	public static void 즐겨찾기_목록_검사(ExtractableResponse<Response> 즐겨찾기_목록_조회_결과, int size, List<String> sourceStationNames) {
+		List<FavoriteResponse> favoriteResponses =
+				즐겨찾기_목록_조회_결과.body().jsonPath().getList("", FavoriteResponse.class);
+//		assertThat(favoriteResponses)
+//				.hasSize(size)
+//				.map(favoriteResponse -> favoriteResponse.getSource().getName())
+//				.asList()
+//				.containsExactly(sourceStationNames);
+	}
+
+	public static ExtractableResponse<Response> 즐겨찾기_삭제_요청(String accessToken, ExtractableResponse<Response> 즐겨찾기_생성_결과) {
+		String uri = 즐겨찾기_생성_결과.header("Location");
+		return RestAssured
+				.given().log().all().auth().oauth2(accessToken)
+				.accept(MediaType.APPLICATION_JSON_VALUE)
+				.when().delete(uri)
+				.then().log().all()
+				.extract();
+	}
+
+	public static void 즐겨찾기_삭제됨(ExtractableResponse<Response> 즐겨찾기_삭제_결과) {
+		assertThat(즐겨찾기_삭제_결과.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+	}
+}

--- a/src/test/java/nextstep/subway/favorite/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/favorite/FavoriteAcceptanceTest.java
@@ -1,8 +1,62 @@
 package nextstep.subway.favorite;
 
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
+import nextstep.subway.line.acceptance.LineAcceptanceTest;
+import nextstep.subway.line.acceptance.LineSectionAcceptanceSupport;
+import nextstep.subway.line.dto.LineRequest;
+import nextstep.subway.line.dto.LineResponse;
+import nextstep.subway.member.MemberAcceptanceSupport;
+import nextstep.subway.station.StationAcceptanceTest;
+import nextstep.subway.station.dto.StationResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.util.Arrays;
 
 @DisplayName("즐겨찾기 관련 기능")
 public class FavoriteAcceptanceTest extends AcceptanceTest {
+
+	private StationResponse 잠실역;
+	private StationResponse 선릉역;
+	private StationResponse 건대역;
+	private LineResponse 이호선;
+	private String accessToken;
+
+	@Override
+	@BeforeEach
+	public void setUp() {
+		super.setUp();
+		잠실역 = StationAcceptanceTest.지하철역_등록되어_있음("잠실역").as(StationResponse.class);
+		선릉역 = StationAcceptanceTest.지하철역_등록되어_있음("선릉역").as(StationResponse.class);
+		건대역 = StationAcceptanceTest.지하철역_등록되어_있음("건대역").as(StationResponse.class);
+
+		이호선 = LineAcceptanceTest.지하철_노선_등록되어_있음(new LineRequest("이호선", "green", 잠실역.getId(), 선릉역.getId(), 10))
+				.as(LineResponse.class);
+		LineSectionAcceptanceSupport.지하철_노선에_지하철역_등록_요청(이호선, 건대역, 잠실역, 5);
+
+		MemberAcceptanceSupport.회원_생성을_요청("any", "any", 50);
+		accessToken = MemberAcceptanceSupport.회원_로그인_요청("any", "any");
+	}
+
+	@DisplayName("즐겨찾기를 관리한다.")
+	@Test
+	void manage() {
+		// 즐겨찾기 생성
+		ExtractableResponse<Response> 즐겨찾기_잠실역_생성_결과 = FavoriteAcceptanceSupport.즐겨찾기_생성_요청(accessToken, 잠실역, 선릉역);
+		FavoriteAcceptanceSupport.즐겨찾기_생성됨(즐겨찾기_잠실역_생성_결과);
+		ExtractableResponse<Response> 즐겨찾기_건대역_생성_결과 = FavoriteAcceptanceSupport.즐겨찾기_생성_요청(accessToken, 건대역, 선릉역);
+		FavoriteAcceptanceSupport.즐겨찾기_생성됨(즐겨찾기_건대역_생성_결과);
+
+		// 즐겨찾기 조회
+		ExtractableResponse<Response> 즐겨찾기_목록_조회_결과 = FavoriteAcceptanceSupport.즐겨찾기_목록_조회_요청(accessToken);
+		FavoriteAcceptanceSupport.즐겨찾기_목록_검사(즐겨찾기_목록_조회_결과, 2, Arrays.asList("잠실역", "건대역"));
+
+		// 즐겨찾기 삭제
+		ExtractableResponse<Response> 즐겨찾기_삭제_결과 = FavoriteAcceptanceSupport.즐겨찾기_삭제_요청(accessToken, 즐겨찾기_잠실역_생성_결과);
+		FavoriteAcceptanceSupport.즐겨찾기_삭제됨(즐겨찾기_삭제_결과);
+		FavoriteAcceptanceSupport.즐겨찾기_목록_검사(FavoriteAcceptanceSupport.즐겨찾기_목록_조회_요청(accessToken), 1, Arrays.asList("건대역"));
+	}
 }

--- a/src/test/java/nextstep/subway/favorite/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/favorite/FavoriteAcceptanceTest.java
@@ -24,6 +24,7 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
 	private StationResponse 건대역;
 	private LineResponse 이호선;
 	private String accessToken;
+	private String otherAccessToken;
 
 	@Override
 	@BeforeEach
@@ -39,6 +40,9 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
 
 		MemberAcceptanceSupport.회원_생성을_요청("any", "any", 50);
 		accessToken = MemberAcceptanceSupport.회원_로그인_요청("any", "any");
+
+		MemberAcceptanceSupport.회원_생성을_요청("any2", "any2", 50);
+		otherAccessToken = MemberAcceptanceSupport.회원_로그인_요청("any2", "any2");
 	}
 
 	@DisplayName("즐겨찾기를 관리한다.")
@@ -58,5 +62,17 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
 		ExtractableResponse<Response> 즐겨찾기_삭제_결과 = FavoriteAcceptanceSupport.즐겨찾기_삭제_요청(accessToken, 즐겨찾기_잠실역_생성_결과);
 		FavoriteAcceptanceSupport.즐겨찾기_삭제됨(즐겨찾기_삭제_결과);
 		FavoriteAcceptanceSupport.즐겨찾기_목록_검사(FavoriteAcceptanceSupport.즐겨찾기_목록_조회_요청(accessToken), 1, Arrays.asList("건대역"));
+	}
+
+	@DisplayName("다른사람의 즐겨찾기는 공개가 되지 않아 삭제할 수 없다.")
+	@Test
+	void deleteByOther() {
+		// 즐겨찾기 생성
+		ExtractableResponse<Response> 즐겨찾기_잠실역_생성_결과 = FavoriteAcceptanceSupport.즐겨찾기_생성_요청(otherAccessToken, 잠실역, 선릉역);
+		FavoriteAcceptanceSupport.즐겨찾기_생성됨(즐겨찾기_잠실역_생성_결과);
+
+		// 즐겨찾기 삭제
+		ExtractableResponse<Response> 즐겨찾기_삭제_결과 = FavoriteAcceptanceSupport.즐겨찾기_삭제_요청(accessToken, 즐겨찾기_잠실역_생성_결과);
+		FavoriteAcceptanceSupport.즐겨찾기_삭제_실패함(즐겨찾기_삭제_결과);
 	}
 }

--- a/src/test/java/nextstep/subway/favorite/application/FavoriteServiceTest.java
+++ b/src/test/java/nextstep/subway/favorite/application/FavoriteServiceTest.java
@@ -2,14 +2,18 @@ package nextstep.subway.favorite.application;
 
 import nextstep.subway.auth.domain.LoginMember;
 import nextstep.subway.favorite.domain.Favorite;
+import nextstep.subway.favorite.domain.FavoriteRepository;
 import nextstep.subway.favorite.dto.FavoriteRequest;
 import nextstep.subway.favorite.dto.FavoriteResponse;
 import nextstep.subway.member.domain.Member;
+import nextstep.subway.member.domain.MemberRepository;
 import nextstep.subway.station.domain.Station;
+import nextstep.subway.station.domain.StationRepository;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.persistence.EntityManager;
 
@@ -23,6 +27,14 @@ class FavoriteServiceTest {
 	private EntityManager em;
 
 	@Autowired
+	private FavoriteRepository favoriteRepository;
+
+	@Autowired
+	private StationRepository stationRepository;
+
+	@Autowired
+	private MemberRepository memberRepository;
+
 	private FavoriteService favoriteService;
 
 	private Station 역1;
@@ -34,7 +46,9 @@ class FavoriteServiceTest {
 	private LoginMember 다른사람;
 
 	@BeforeEach
+	@Transactional
 	void setUp() {
+		favoriteService = new FavoriteService(favoriteRepository, stationRepository, memberRepository);
 		주인Member = new Member("2mail", "e", 30);
 		다른사람Member = new Member("email", "d", 50);
 		역1 = new Station("역1");
@@ -45,6 +59,7 @@ class FavoriteServiceTest {
 		em.persist(역2);
 		주인 = new LoginMember(주인Member.getId(), 주인Member.getEmail(), 주인Member.getAge());
 		다른사람 = new LoginMember(다른사람Member.getId(), 다른사람Member.getEmail(), 다른사람Member.getAge());
+		em.clear();
 	}
 
 	@Test

--- a/src/test/java/nextstep/subway/favorite/application/FavoriteServiceTest.java
+++ b/src/test/java/nextstep/subway/favorite/application/FavoriteServiceTest.java
@@ -1,0 +1,152 @@
+package nextstep.subway.favorite.application;
+
+import nextstep.subway.auth.domain.LoginMember;
+import nextstep.subway.favorite.domain.Favorite;
+import nextstep.subway.favorite.dto.FavoriteRequest;
+import nextstep.subway.favorite.dto.FavoriteResponse;
+import nextstep.subway.member.domain.Member;
+import nextstep.subway.station.domain.Station;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+import javax.persistence.EntityManager;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@DataJpaTest
+class FavoriteServiceTest {
+
+	@Autowired
+	private EntityManager em;
+
+	@Autowired
+	private FavoriteService favoriteService;
+
+	private Station 역1;
+	private Station 역2;
+	private Member 주인Member;
+	private Member 다른사람Member;
+
+	private LoginMember 주인;
+	private LoginMember 다른사람;
+
+	@BeforeEach
+	void setUp() {
+		주인Member = new Member("2mail", "e", 30);
+		다른사람Member = new Member("email", "d", 50);
+		역1 = new Station("역1");
+		역2 = new Station("역2");
+		em.persist(주인Member);
+		em.persist(다른사람Member);
+		em.persist(역1);
+		em.persist(역2);
+		주인 = new LoginMember(주인Member.getId(), 주인Member.getEmail(), 주인Member.getAge());
+		다른사람 = new LoginMember(다른사람Member.getId(), 다른사람Member.getEmail(), 다른사람Member.getAge());
+	}
+
+	@Test
+	void getFavorites() {
+		// given
+		Favorite 즐겨찾기1 = new Favorite(주인Member, 역1, 역2);
+		Favorite 즐겨찾기2 = new Favorite(주인Member, 역2, 역1);
+		em.persist(즐겨찾기1);
+		em.persist(즐겨찾기2);
+
+		// when then
+		assertThat(favoriteService.getFavorites(주인))
+				.hasSize(2)
+				.map(favoriteResponse -> favoriteResponse.getSource().getName())
+				.containsExactly(즐겨찾기1.getSource().getName(), 즐겨찾기2.getSource().getName());
+		assertThat(favoriteService.getFavorites(다른사람))
+				.hasSize(0);
+	}
+
+	@Test
+	void createFavorite() {
+		// given
+		FavoriteRequest favoriteRequest = new FavoriteRequest(역1.getId(), 역2.getId());
+
+		// when
+		FavoriteResponse favoriteResponse = favoriteService.createFavorite(주인, favoriteRequest);
+
+		// then
+		assertThat(favoriteResponse.getId()).isNotNull();
+		assertThat(favoriteResponse.getSource().getName()).isEqualTo(역1.getName());
+		assertThat(favoriteResponse.getTarget().getName()).isEqualTo(역2.getName());
+	}
+
+	@Test
+	void createFavorite_역이같은_즐겨찾기_But다른사람() {
+		// given: 기존에 다른사람이 역이 같은 즐겨찾기를 등록해놓음
+		FavoriteRequest favoriteRequest = new FavoriteRequest(역1.getId(), 역2.getId());
+		FavoriteResponse favoriteResponse1 = favoriteService.createFavorite(다른사람, favoriteRequest);
+
+		// when then
+		FavoriteResponse favoriteResponse2 = favoriteService.createFavorite(주인, favoriteRequest);
+		assertThat(favoriteResponse1.getId()).isNotEqualTo(favoriteResponse2.getId());
+	}
+
+	@Test
+	void createFavorite_중복됨() {
+		// given: 기존에 역이 등록되어 있는 상태
+		FavoriteRequest favoriteRequest = new FavoriteRequest(역1.getId(), 역2.getId());
+		favoriteService.createFavorite(주인, favoriteRequest);
+
+		// when then
+		assertThatThrownBy(() -> favoriteService.createFavorite(주인, favoriteRequest))
+				.isInstanceOf(FavoriteValidationException.class)
+				.hasMessageContaining("출발역 도착역이 같은 즐겨찾기가 이미 등록되어 있습니다.");
+	}
+
+	@Test
+	void createFavorite_출발역도착역같음() {
+		// given
+		FavoriteRequest favoriteRequest = new FavoriteRequest(역1.getId(), 역1.getId());
+
+		// when then
+		assertThatThrownBy(() -> favoriteService.createFavorite(주인, favoriteRequest))
+				.isInstanceOf(FavoriteValidationException.class)
+				.hasMessageContaining("출발역 도착역이 같아 등록이 불가능합니다.");
+	}
+
+	@Test
+	void createFavorite_미존재역() {
+		// given
+		FavoriteRequest favoriteRequest = new FavoriteRequest(-1L, -99L);
+
+		// then
+		assertThatThrownBy(() -> favoriteService.createFavorite(주인, favoriteRequest))
+				.isInstanceOf(FavoriteValidationException.class)
+				.hasMessageContaining("존재하지 않는 역을 즐겨찾기로 추가할 수 없습니다.");
+	}
+
+	@Test
+	void deleteFavoriteById() {
+		// given: 기존에 역이 등록되어 있는 상태
+		FavoriteRequest favoriteRequest = new FavoriteRequest(역1.getId(), 역2.getId());
+		FavoriteResponse favoriteResponse = favoriteService.createFavorite(주인, favoriteRequest);
+
+		// when
+		favoriteService.deleteFavoriteById(주인, favoriteResponse.getId());
+
+		// then: 이미 삭제하였으므로 예외발생
+		assertThatThrownBy(() -> favoriteService.deleteFavoriteById(주인, favoriteResponse.getId()))
+				.isInstanceOf(FavoriteValidationException.class)
+				.hasMessageContaining("존재하지 않는 즐겨찾기입니다.");
+	}
+
+	@Test
+	void deleteFavoriteById_다른사람() {
+		// given: 기존에 역이 등록되어 있는 상태
+		FavoriteRequest favoriteRequest = new FavoriteRequest(역1.getId(), 역2.getId());
+		FavoriteResponse favoriteResponse = favoriteService.createFavorite(주인, favoriteRequest);
+
+		// when then: 다른사람이 주인의 즐겨찾기를 삭제
+		assertThatThrownBy(() -> favoriteService.deleteFavoriteById(다른사람, favoriteResponse.getId()))
+				.isInstanceOf(FavoriteValidationException.class)
+				.hasMessageContaining("존재하지 않는 즐겨찾기입니다.");
+	}
+}

--- a/src/test/java/nextstep/subway/member/MemberAcceptanceSupport.java
+++ b/src/test/java/nextstep/subway/member/MemberAcceptanceSupport.java
@@ -1,0 +1,138 @@
+package nextstep.subway.member;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.auth.dto.TokenRequest;
+import nextstep.subway.member.dto.MemberRequest;
+import nextstep.subway.member.dto.MemberResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SuppressWarnings("NonAsciiCharacters")
+public class MemberAcceptanceSupport {
+	public static ExtractableResponse<Response> 회원_생성을_요청(String email, String password, Integer age) {
+	    MemberRequest memberRequest = new MemberRequest(email, password, age);
+
+	    return RestAssured
+	            .given().log().all()
+	            .contentType(MediaType.APPLICATION_JSON_VALUE)
+	            .body(memberRequest)
+	            .when().post("/members")
+	            .then().log().all()
+	            .extract();
+	}
+
+	public static ExtractableResponse<Response> 회원_정보_조회_요청(ExtractableResponse<Response> response) {
+	    String uri = response.header("Location");
+
+	    return RestAssured
+	            .given().log().all()
+	            .accept(MediaType.APPLICATION_JSON_VALUE)
+	            .when().get(uri)
+	            .then().log().all()
+	            .extract();
+	}
+
+	public static ExtractableResponse<Response> 회원_정보_수정_요청(ExtractableResponse<Response> response, String email, String password, Integer age) {
+	    String uri = response.header("Location");
+	    MemberRequest memberRequest = new MemberRequest(email, password, age);
+
+	    return RestAssured
+	            .given().log().all()
+	            .contentType(MediaType.APPLICATION_JSON_VALUE)
+	            .body(memberRequest)
+	            .when().put(uri)
+	            .then().log().all()
+	            .extract();
+	}
+
+	public static ExtractableResponse<Response> 회원_삭제_요청(ExtractableResponse<Response> response) {
+	    String uri = response.header("Location");
+	    return RestAssured
+	            .given().log().all()
+	            .when().delete(uri)
+	            .then().log().all()
+	            .extract();
+	}
+
+	public static void 회원_생성됨(ExtractableResponse<Response> response) {
+	    assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+	}
+
+	public static void 회원_정보_조회됨(ExtractableResponse<Response> response, String email, int age) {
+	    MemberResponse memberResponse = response.as(MemberResponse.class);
+	    assertThat(memberResponse.getId()).isNotNull();
+	    assertThat(memberResponse.getEmail()).isEqualTo(email);
+	    assertThat(memberResponse.getAge()).isEqualTo(age);
+	}
+
+	public static void 회원_정보_수정됨(ExtractableResponse<Response> response) {
+	    assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+	}
+
+	public static void 회원_삭제됨(ExtractableResponse<Response> response) {
+	    assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+	}
+
+	public static String 회원_로그인_요청(String email, String password) {
+		ExtractableResponse<Response> response = RestAssured
+				.given().log().all()
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.body(new TokenRequest(email, password))
+				.when().post("/login/token")
+				.then().log().all().
+						extract();
+
+		return response.body().jsonPath().get("accessToken");
+	}
+
+
+	public static ExtractableResponse<Response> 내_정보_조회_요청(String accessToken) {
+		return RestAssured
+				.given().log().all().auth().oauth2(accessToken)
+				.accept(MediaType.APPLICATION_JSON_VALUE)
+				.when().get("/members/me")
+				.then().log().all()
+				.extract();
+	}
+
+	public static void 내_정보_조회_성공함(ExtractableResponse<Response> 내_정보_조회_결과, String email, int age) {
+		MemberResponse memberResponse = 내_정보_조회_결과.as(MemberResponse.class);
+		assertThat(memberResponse.getEmail()).isEqualTo(email);
+		assertThat(memberResponse.getAge()).isEqualTo(age);
+	}
+
+	public static ExtractableResponse<Response> 내_정보_업데이트(String accessToken, String newEmail, String newPassword, int newAge) {
+		MemberRequest memberRequest = new MemberRequest(newEmail, newPassword, newAge);
+		return RestAssured
+				.given().log().all().auth().oauth2(accessToken)
+				.contentType(MediaType.APPLICATION_JSON_VALUE)
+				.body(memberRequest)
+				.when().put("/members/me")
+				.then().log().all()
+				.extract();
+	}
+
+	public static void 내_정보_업데이트_성공함(ExtractableResponse<Response> 내_정보_업데이트_결과) {
+		assertThat(내_정보_업데이트_결과.statusCode()).isEqualTo(HttpStatus.OK.value());
+	}
+
+	public static ExtractableResponse<Response> 내_정보_삭제(String accessToken) {
+		return RestAssured
+				.given().log().all().auth().oauth2(accessToken)
+				.when().delete("/members/me")
+				.then().log().all()
+				.extract();
+	}
+
+	public static void 냬_정보_삭제_성공함(ExtractableResponse<Response> 내_정보_삭제_결과) {
+		assertThat(내_정보_삭제_결과.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+	}
+
+	public static void 내_정보_조회_실패함(ExtractableResponse<Response> 내_정보_조회_요청) {
+		assertThat(내_정보_조회_요청.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+	}
+}

--- a/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
@@ -1,18 +1,12 @@
 package nextstep.subway.member;
 
-import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
-import nextstep.subway.member.dto.MemberRequest;
-import nextstep.subway.member.dto.MemberResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
+@SuppressWarnings("NonAsciiCharacters")
 public class MemberAcceptanceTest extends AcceptanceTest {
     public static final String EMAIL = "email@email.com";
     public static final String PASSWORD = "password";
@@ -25,93 +19,47 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @Test
     void manageMember() {
         // when
-        ExtractableResponse<Response> createResponse = 회원_생성을_요청(EMAIL, PASSWORD, AGE);
+        ExtractableResponse<Response> createResponse = MemberAcceptanceSupport.회원_생성을_요청(EMAIL, PASSWORD, AGE);
         // then
-        회원_생성됨(createResponse);
+        MemberAcceptanceSupport.회원_생성됨(createResponse);
 
         // when
-        ExtractableResponse<Response> findResponse = 회원_정보_조회_요청(createResponse);
+        ExtractableResponse<Response> findResponse = MemberAcceptanceSupport.회원_정보_조회_요청(createResponse);
         // then
-        회원_정보_조회됨(findResponse, EMAIL, AGE);
+        MemberAcceptanceSupport.회원_정보_조회됨(findResponse, EMAIL, AGE);
 
         // when
-        ExtractableResponse<Response> updateResponse = 회원_정보_수정_요청(createResponse, NEW_EMAIL, NEW_PASSWORD, NEW_AGE);
+        ExtractableResponse<Response> updateResponse = MemberAcceptanceSupport.회원_정보_수정_요청(createResponse, NEW_EMAIL, NEW_PASSWORD, NEW_AGE);
         // then
-        회원_정보_수정됨(updateResponse);
+        MemberAcceptanceSupport.회원_정보_수정됨(updateResponse);
 
         // when
-        ExtractableResponse<Response> deleteResponse = 회원_삭제_요청(createResponse);
+        ExtractableResponse<Response> deleteResponse = MemberAcceptanceSupport.회원_삭제_요청(createResponse);
         // then
-        회원_삭제됨(deleteResponse);
+        MemberAcceptanceSupport.회원_삭제됨(deleteResponse);
     }
 
     @DisplayName("나의 정보를 관리한다.")
     @Test
     void manageMyInfo() {
+        // 로그인 절차
+        MemberAcceptanceSupport.회원_생성을_요청(EMAIL, PASSWORD, AGE);
+        String accessToken = MemberAcceptanceSupport.회원_로그인_요청(EMAIL, PASSWORD);
 
+        // 조회
+        ExtractableResponse<Response> 내_정보_조회_결과 = MemberAcceptanceSupport.내_정보_조회_요청(accessToken);
+        MemberAcceptanceSupport.내_정보_조회_성공함(내_정보_조회_결과, EMAIL, AGE);
+
+        // 업데이트
+        ExtractableResponse<Response> 내_정보_업데이트_결과 = MemberAcceptanceSupport.내_정보_업데이트(accessToken, NEW_EMAIL, NEW_PASSWORD, NEW_AGE);
+        MemberAcceptanceSupport.내_정보_업데이트_성공함(내_정보_업데이트_결과);
+        accessToken = MemberAcceptanceSupport.회원_로그인_요청(NEW_EMAIL, NEW_PASSWORD);
+        MemberAcceptanceSupport.내_정보_조회_성공함(MemberAcceptanceSupport.내_정보_조회_요청(accessToken), NEW_EMAIL, NEW_AGE);
+
+        // 삭제
+        ExtractableResponse<Response> 내_정보_삭제_결과 = MemberAcceptanceSupport.내_정보_삭제(accessToken);
+        MemberAcceptanceSupport.냬_정보_삭제_성공함(내_정보_삭제_결과);
+        MemberAcceptanceSupport.내_정보_조회_실패함(MemberAcceptanceSupport.내_정보_조회_요청(accessToken));
     }
 
-    public static ExtractableResponse<Response> 회원_생성을_요청(String email, String password, Integer age) {
-        MemberRequest memberRequest = new MemberRequest(email, password, age);
-
-        return RestAssured
-                .given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(memberRequest)
-                .when().post("/members")
-                .then().log().all()
-                .extract();
-    }
-
-    public static ExtractableResponse<Response> 회원_정보_조회_요청(ExtractableResponse<Response> response) {
-        String uri = response.header("Location");
-
-        return RestAssured
-                .given().log().all()
-                .accept(MediaType.APPLICATION_JSON_VALUE)
-                .when().get(uri)
-                .then().log().all()
-                .extract();
-    }
-
-    public static ExtractableResponse<Response> 회원_정보_수정_요청(ExtractableResponse<Response> response, String email, String password, Integer age) {
-        String uri = response.header("Location");
-        MemberRequest memberRequest = new MemberRequest(email, password, age);
-
-        return RestAssured
-                .given().log().all()
-                .contentType(MediaType.APPLICATION_JSON_VALUE)
-                .body(memberRequest)
-                .when().put(uri)
-                .then().log().all()
-                .extract();
-    }
-
-    public static ExtractableResponse<Response> 회원_삭제_요청(ExtractableResponse<Response> response) {
-        String uri = response.header("Location");
-        return RestAssured
-                .given().log().all()
-                .when().delete(uri)
-                .then().log().all()
-                .extract();
-    }
-
-    public static void 회원_생성됨(ExtractableResponse<Response> response) {
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
-    }
-
-    public static void 회원_정보_조회됨(ExtractableResponse<Response> response, String email, int age) {
-        MemberResponse memberResponse = response.as(MemberResponse.class);
-        assertThat(memberResponse.getId()).isNotNull();
-        assertThat(memberResponse.getEmail()).isEqualTo(email);
-        assertThat(memberResponse.getAge()).isEqualTo(age);
-    }
-
-    public static void 회원_정보_수정됨(ExtractableResponse<Response> response) {
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
-    }
-
-    public static void 회원_삭제됨(ExtractableResponse<Response> response) {
-        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
-    }
 }


### PR DESCRIPTION
안녕하세요.

--
이번에 즐겨찾기 기능을 구현하면서 이전에 말씀하신 현업에서의 OutsideIn 개발 방식을 따라해보았습니다.
확실히 테스트가 블랙박스 방식에 가까워지면서 mocking 에 대한 부담도 많이 사라지고 쿼리를 볼 수 있고 다양한 장점을 느꼈습니다.
(물론 완벽한 유닛테스트에서 점점 멀어지긴 하지만요 ㅎㅎ)
이 부분에 대해서 현업과 얼마나 유사한지 피드백을 주시면 저한테 큰 도움이 될 것 같습니다.

--
지난번에 피드백을 받았다시피 레포지토리에 접근하는 횟수를 최대한 줄이고자 하였습니다.
다만 이 과정을 진행하면서 현재 프로젝트에서 @AutenticationPrincipal 을 통해서 갖고 오는 인증 정보가 왜 엔티티가 아닌지 궁금해졌습니다.
예를 들면 즐겨찾기를 생성하는 API 를 호출하면

[트랜잭션1] (인증정보 갖고오기, @AuthenticationPrincipal 을 통해 트리거)
1. 토큰 -> Member 로 변환하기 위해 Repository 접근
2. Member -> LoginMember(VO) 로 리턴

[트랜잭션2] (즐겨찾기 생성)
...(전단계 생략)
1. LoginMember -> Member 로 변환하기 위해  Id로 Repository 접근
2. Member 를 이용하여 new Favorite(Member, station, station)

이렇게 두개의 트랜잭션이 생겨서 결국 한번 더 Member 정보를 갖고오는 일이 발생합니다.
트랜잭션이 나뉘니 이렇게 받은 LoginMember 가 무조건 유효한 상태가 아닐 경우도 발생할 것 같고요.

물론 LoginMember 를 사용하는건 Member 엔티티의 변경을 막기 위해서인 것 같습니다만
만약 이게 큰 프로젝트라면 인증이 필요한 API 를 호출할때마다 불필요한 DB 접근이 한번 더 발생하게 되는데요,
이건 결국 프로젝트별 선택의 문제인건지 아님 일반적인 정답이 존재하는건지 궁금합니다 🙇🏻‍♂️.

--
항상 배움이 되는 피드백 감사드립니다 ! 