### PR TITLE
[STEP3] 인증을 통한 기능 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,45 @@ Scenario: 지하철 구간을 관리
   * Outside-in 으로 구현 (추 후 inside-out 개별 학습)
 * 예외사항 단위테스트 작성하여 처리확인
 
+## [STEP3] 인증을 통한 기능 구현
+* 토큰 발급 기능 (로그인) 완성하기
+  * 인수 테스트 만들기 (AuthAcceptanceTest)
+  * 이메일과 패스워드를 이용하여 요청 시 access token을 응답하는 기능을 구현하기
+* 내 정보 조회 기능 완성하기
+  * MemberAcceptanceTest 클래스의 manageMyInfo메서드에 인수 테스트를 추가
+  * 내 정보 조회 인수테스트 만들기
+  * 내 정보 조회 기능 구현
+  * 내 정보 수정 인수테스트 만들기
+  * 내 정보 수정 기능 구현
+  * 내 정보 삭제 인수테스트 만들기
+  * 내 정보 삭제 구현
+    * 로그인 후 발급 받은 토큰을 포함해서 요청 하기 
+    * @AuthenticationPrincipal과 AuthenticationPrincipalArgumentResolver을 활용
+    * 유효하지 않은 토큰으로 /members/me 요청을 보낼 경우에 대한 예외 처리
+* 즐겨 찾기 기능 완성하기
+  * 즐겨찾기 생성 인수테스트 만들기
+  * 즐겨찾기 생성 기능 구현
+  * 즐겨찾기 목록 조회 인수테스트 만들기
+  * 즐겨찾기 목록 조회 기능 구현
+  * 즐겨찾기 삭제 인수테스트 만들기
+  * 즐겨찾기 삭제 기능 구현
+```
+Feature: 즐겨찾기를 관리한다.
+  Background 
+    Given 지하철역 등록되어 있음
+    And 지하철 노선 등록되어 있음
+    And 지하철 노선에 지하철역 등록되어 있음
+    And 회원 등록되어 있음
+    And 로그인 되어있음
+
+  Scenario: 즐겨찾기를 관리
+    When 즐겨찾기 생성을 요청
+    Then 즐겨찾기 생성됨
+    When 즐겨찾기 목록 조회 요청
+    Then 즐겨찾기 목록 조회됨
+    When 즐겨찾기 삭제 요청
+    Then 즐겨찾기 삭제됨
+```
 <br>
 
 ## 🚀 Getting Started

--- a/README.md
+++ b/README.md
@@ -99,12 +99,6 @@ Scenario: 지하철 구간을 관리
   * 이메일과 패스워드를 이용하여 요청 시 access token을 응답하는 기능을 구현하기
 * 내 정보 조회 기능 완성하기
   * MemberAcceptanceTest 클래스의 manageMyInfo메서드에 인수 테스트를 추가
-  * 내 정보 조회 인수테스트 만들기
-  * 내 정보 조회 기능 구현
-  * 내 정보 수정 인수테스트 만들기
-  * 내 정보 수정 기능 구현
-  * 내 정보 삭제 인수테스트 만들기
-  * 내 정보 삭제 구현
     * 로그인 후 발급 받은 토큰을 포함해서 요청 하기 
     * @AuthenticationPrincipal과 AuthenticationPrincipalArgumentResolver을 활용
     * 유효하지 않은 토큰으로 /members/me 요청을 보낼 경우에 대한 예외 처리

--- a/README.md
+++ b/README.md
@@ -103,11 +103,9 @@ Scenario: 지하철 구간을 관리
     * @AuthenticationPrincipal과 AuthenticationPrincipalArgumentResolver을 활용
     * 유효하지 않은 토큰으로 /members/me 요청을 보낼 경우에 대한 예외 처리
 * 즐겨 찾기 기능 완성하기
-  * 즐겨찾기 생성 인수테스트 만들기
+  * 즐겨찾기 생성 / 목록 조회 / 삭제 통합 인수테스트 만들기
   * 즐겨찾기 생성 기능 구현
-  * 즐겨찾기 목록 조회 인수테스트 만들기
   * 즐겨찾기 목록 조회 기능 구현
-  * 즐겨찾기 삭제 인수테스트 만들기
   * 즐겨찾기 삭제 기능 구현
 ```
 Feature: 즐겨찾기를 관리한다.

--- a/src/main/java/nextstep/subway/auth/application/AuthService.java
+++ b/src/main/java/nextstep/subway/auth/application/AuthService.java
@@ -7,7 +7,6 @@ import nextstep.subway.auth.infrastructure.JwtTokenProvider;
 import nextstep.subway.member.domain.Member;
 import nextstep.subway.member.domain.MemberRepository;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class AuthService {
@@ -20,7 +19,8 @@ public class AuthService {
     }
 
     public TokenResponse login(TokenRequest request) {
-        Member member = memberRepository.findByEmail(request.getEmail()).orElseThrow(AuthorizationException::new);
+        Member member = memberRepository.findByEmail(request.getEmail())
+            .orElseThrow(() -> new AuthorizationException("로그인 정보가 일치하지 않습니다."));
         member.checkPassword(request.getPassword());
 
         String token = jwtTokenProvider.createToken(request.getEmail());
@@ -33,7 +33,8 @@ public class AuthService {
         }
 
         String email = jwtTokenProvider.getPayload(credentials);
-        Member member = memberRepository.findByEmail(email).orElseThrow(RuntimeException::new);
+        Member member = memberRepository.findByEmail(email)
+            .orElseThrow(() -> new AuthorizationException("유효하지 않은 인증 정보 입니다."));
         return new LoginMember(member.getId(), member.getEmail(), member.getAge());
     }
 }

--- a/src/main/java/nextstep/subway/auth/application/AuthService.java
+++ b/src/main/java/nextstep/subway/auth/application/AuthService.java
@@ -29,7 +29,7 @@ public class AuthService {
 
     public LoginMember findMemberByToken(String credentials) {
         if (!jwtTokenProvider.validateToken(credentials)) {
-            return new LoginMember();
+            throw new AuthorizationException("유효하지 않은 인증 정보 입니다.");
         }
 
         String email = jwtTokenProvider.getPayload(credentials);

--- a/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
+++ b/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
@@ -47,4 +47,14 @@ public class FavoriteService {
 			.map(FavoriteResponse::of)
 			.collect(Collectors.toList());
 	}
+
+	public void removeFavoriteByIdAndMember(Long id, Long memberId) {
+		Favorite favorite = favoriteRepository.findById(id)
+			.orElseThrow(() -> new IllegalArgumentException("등록되지 않은 즐겨찾기 입니다."));
+
+		if (!favorite.belongTo(memberId)) {
+			throw new IllegalArgumentException("해당 회원에게 등록되지 않은 즐겨찾기 입니다.");
+		}
+		favoriteRepository.deleteById(id);
+	}
 }

--- a/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
+++ b/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
@@ -28,12 +28,16 @@ public class FavoriteService {
 	}
 
 	public FavoriteResponse saveFavorite(FavoriteRequest favoriteRequest, Long memberId) {
-		Station sourceStation = stationRepository.findById(favoriteRequest.getSourceId())
+		Station sourceStation = stationRepository.findById(favoriteRequest.getSource())
 			.orElseThrow(() -> new IllegalArgumentException("즐겨찾기를 등록할 수 없는 지하철 역 입니다."));
-		Station targetStation = stationRepository.findById(favoriteRequest.getTargetId())
+		Station targetStation = stationRepository.findById(favoriteRequest.getTarget())
 			.orElseThrow(() -> new IllegalArgumentException("즐겨찾기를 등록할 수 없는 지하철 역 입니다."));
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new IllegalArgumentException("등록되지 않은 회원 입니다."));
+
+		if (favoriteRepository.existsByMemberAndSourceStationAndTargetStation(member, sourceStation, targetStation)) {
+			throw new IllegalArgumentException("이미 등록된 즐겨찾기 입니다.");
+		}
 
 		Favorite favorite = favoriteRepository.save(new Favorite(member, sourceStation, targetStation));
 		return FavoriteResponse.of(favorite);

--- a/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
+++ b/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
@@ -29,9 +29,9 @@ public class FavoriteService {
 
 	public FavoriteResponse saveFavorite(FavoriteRequest favoriteRequest, Long memberId) {
 		Station sourceStation = stationRepository.findById(favoriteRequest.getSource())
-			.orElseThrow(() -> new IllegalArgumentException("즐겨찾기를 등록할 수 없는 지하철 역 입니다."));
+			.orElseThrow(() -> new IllegalArgumentException("등록되지 않은 지하철 역 입니다."));
 		Station targetStation = stationRepository.findById(favoriteRequest.getTarget())
-			.orElseThrow(() -> new IllegalArgumentException("즐겨찾기를 등록할 수 없는 지하철 역 입니다."));
+			.orElseThrow(() -> new IllegalArgumentException("등록되지 않은 지하철 역 입니다."));
 		Member member = memberRepository.findById(memberId)
 			.orElseThrow(() -> new IllegalArgumentException("등록되지 않은 회원 입니다."));
 

--- a/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
+++ b/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
@@ -1,0 +1,38 @@
+package nextstep.subway.favorite.application;
+
+import org.springframework.stereotype.Service;
+
+import nextstep.subway.favorite.domain.Favorite;
+import nextstep.subway.favorite.domain.FavoriteRepository;
+import nextstep.subway.favorite.dto.FavoriteRequest;
+import nextstep.subway.favorite.dto.FavoriteResponse;
+import nextstep.subway.member.domain.Member;
+import nextstep.subway.member.domain.MemberRepository;
+import nextstep.subway.station.domain.Station;
+import nextstep.subway.station.domain.StationRepository;
+
+@Service
+public class FavoriteService {
+	private FavoriteRepository favoriteRepository;
+	private StationRepository stationRepository;
+	private MemberRepository memberRepository;
+
+	public FavoriteService(FavoriteRepository favoriteRepository,
+		StationRepository stationRepository, MemberRepository memberRepository) {
+		this.favoriteRepository = favoriteRepository;
+		this.stationRepository = stationRepository;
+		this.memberRepository = memberRepository;
+	}
+
+	public FavoriteResponse saveFavorite(FavoriteRequest favoriteRequest, Long memberId) {
+		Station sourceStation = stationRepository.findById(favoriteRequest.getSourceId())
+			.orElseThrow(() -> new IllegalArgumentException("즐겨찾기를 등록할 수 없는 지하철 역 입니다."));
+		Station targetStation = stationRepository.findById(favoriteRequest.getTargetId())
+			.orElseThrow(() -> new IllegalArgumentException("즐겨찾기를 등록할 수 없는 지하철 역 입니다."));
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new IllegalArgumentException("즐겨찾기를 등록할 수 없는 회원 입니다."));
+
+		Favorite favorite = favoriteRepository.save(new Favorite(member, sourceStation, targetStation));
+		return FavoriteResponse.of(favorite);
+	}
+}

--- a/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
+++ b/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
@@ -1,5 +1,8 @@
 package nextstep.subway.favorite.application;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 import org.springframework.stereotype.Service;
 
 import nextstep.subway.favorite.domain.Favorite;
@@ -30,9 +33,18 @@ public class FavoriteService {
 		Station targetStation = stationRepository.findById(favoriteRequest.getTargetId())
 			.orElseThrow(() -> new IllegalArgumentException("즐겨찾기를 등록할 수 없는 지하철 역 입니다."));
 		Member member = memberRepository.findById(memberId)
-			.orElseThrow(() -> new IllegalArgumentException("즐겨찾기를 등록할 수 없는 회원 입니다."));
+			.orElseThrow(() -> new IllegalArgumentException("등록되지 않은 회원 입니다."));
 
 		Favorite favorite = favoriteRepository.save(new Favorite(member, sourceStation, targetStation));
 		return FavoriteResponse.of(favorite);
+	}
+
+	public List<FavoriteResponse> findAllFavoritesByMember(Long memberId) {
+		Member member = memberRepository.findById(memberId)
+			.orElseThrow(() -> new IllegalArgumentException("등록되지 않은 회원 입니다."));
+
+		return favoriteRepository.findByMember(member).stream()
+			.map(FavoriteResponse::of)
+			.collect(Collectors.toList());
 	}
 }

--- a/src/main/java/nextstep/subway/favorite/domain/Favorite.java
+++ b/src/main/java/nextstep/subway/favorite/domain/Favorite.java
@@ -1,0 +1,55 @@
+package nextstep.subway.favorite.domain;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.ManyToOne;
+
+import nextstep.subway.BaseEntity;
+import nextstep.subway.member.domain.Member;
+import nextstep.subway.station.domain.Station;
+
+@Entity
+public class Favorite extends BaseEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne
+	private Member member;
+
+	@ManyToOne
+	private Station sourceStation;
+
+	@ManyToOne
+	private Station targetStation;
+
+	protected Favorite() {
+	}
+
+	public Favorite(Long id, Member member, Station sourceStation, Station targetStation) {
+		this.id = id;
+		this.member = member;
+		this.sourceStation = sourceStation;
+		this.targetStation = targetStation;
+	}
+
+	public Favorite(Member member, Station sourceStation, Station targetStation) {
+		this.member = member;
+		this.sourceStation = sourceStation;
+		this.targetStation = targetStation;
+	}
+
+	public Long getId() {
+		return id;
+	}
+
+	public Station getSourceStation() {
+		return sourceStation;
+	}
+
+	public Station getTargetStation() {
+		return targetStation;
+	}
+}

--- a/src/main/java/nextstep/subway/favorite/domain/Favorite.java
+++ b/src/main/java/nextstep/subway/favorite/domain/Favorite.java
@@ -28,13 +28,6 @@ public class Favorite extends BaseEntity {
 	protected Favorite() {
 	}
 
-	public Favorite(Long id, Member member, Station sourceStation, Station targetStation) {
-		this.id = id;
-		this.member = member;
-		this.sourceStation = sourceStation;
-		this.targetStation = targetStation;
-	}
-
 	public Favorite(Member member, Station sourceStation, Station targetStation) {
 		this.member = member;
 		this.sourceStation = sourceStation;
@@ -45,11 +38,22 @@ public class Favorite extends BaseEntity {
 		return id;
 	}
 
+	public Member getMember() {
+		return member;
+	}
+
 	public Station getSourceStation() {
 		return sourceStation;
 	}
 
 	public Station getTargetStation() {
 		return targetStation;
+	}
+
+	public boolean belongTo(Long memberId) {
+		if (this.member == null) {
+			return false;
+		}
+		return this.member.getId().equals(memberId);
 	}
 }

--- a/src/main/java/nextstep/subway/favorite/domain/FavoriteRepository.java
+++ b/src/main/java/nextstep/subway/favorite/domain/FavoriteRepository.java
@@ -1,0 +1,8 @@
+package nextstep.subway.favorite.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+}

--- a/src/main/java/nextstep/subway/favorite/domain/FavoriteRepository.java
+++ b/src/main/java/nextstep/subway/favorite/domain/FavoriteRepository.java
@@ -6,8 +6,11 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 import nextstep.subway.member.domain.Member;
+import nextstep.subway.station.domain.Station;
 
 @Repository
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
 	List<Favorite> findByMember(Member member);
+
+	boolean existsByMemberAndSourceStationAndTargetStation(Member member, Station sourceStation, Station targetStation);
 }

--- a/src/main/java/nextstep/subway/favorite/domain/FavoriteRepository.java
+++ b/src/main/java/nextstep/subway/favorite/domain/FavoriteRepository.java
@@ -1,8 +1,13 @@
 package nextstep.subway.favorite.domain;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import nextstep.subway.member.domain.Member;
+
 @Repository
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+	List<Favorite> findByMember(Member member);
 }

--- a/src/main/java/nextstep/subway/favorite/dto/FavoriteRequest.java
+++ b/src/main/java/nextstep/subway/favorite/dto/FavoriteRequest.java
@@ -1,0 +1,22 @@
+package nextstep.subway.favorite.dto;
+
+public class FavoriteRequest {
+	private Long sourceId;
+	private Long targetId;
+
+	public FavoriteRequest() {
+	}
+
+	public FavoriteRequest(Long sourceId, Long targetId) {
+		this.sourceId = sourceId;
+		this.targetId = targetId;
+	}
+
+	public Long getSourceId() {
+		return sourceId;
+	}
+
+	public Long getTargetId() {
+		return targetId;
+	}
+}

--- a/src/main/java/nextstep/subway/favorite/dto/FavoriteRequest.java
+++ b/src/main/java/nextstep/subway/favorite/dto/FavoriteRequest.java
@@ -1,22 +1,22 @@
 package nextstep.subway.favorite.dto;
 
 public class FavoriteRequest {
-	private Long sourceId;
-	private Long targetId;
+	private Long source;
+	private Long target;
 
 	public FavoriteRequest() {
 	}
 
-	public FavoriteRequest(Long sourceId, Long targetId) {
-		this.sourceId = sourceId;
-		this.targetId = targetId;
+	public FavoriteRequest(Long source, Long target) {
+		this.source = source;
+		this.target = target;
 	}
 
-	public Long getSourceId() {
-		return sourceId;
+	public Long getSource() {
+		return source;
 	}
 
-	public Long getTargetId() {
-		return targetId;
+	public Long getTarget() {
+		return target;
 	}
 }

--- a/src/main/java/nextstep/subway/favorite/dto/FavoriteResponse.java
+++ b/src/main/java/nextstep/subway/favorite/dto/FavoriteResponse.java
@@ -1,0 +1,22 @@
+package nextstep.subway.favorite.dto;
+
+import nextstep.subway.station.dto.StationResponse;
+
+public class FavoriteResponse {
+	private Long id;
+	private StationResponse source;
+	private StationResponse target;
+
+	protected FavoriteResponse() {
+	}
+
+	public FavoriteResponse(Long id, StationResponse source, StationResponse target) {
+		this.id = id;
+		this.source = source;
+		this.target = target;
+	}
+
+	public Long getId() {
+		return id;
+	}
+}

--- a/src/main/java/nextstep/subway/favorite/dto/FavoriteResponse.java
+++ b/src/main/java/nextstep/subway/favorite/dto/FavoriteResponse.java
@@ -26,4 +26,12 @@ public class FavoriteResponse {
 	public Long getId() {
 		return id;
 	}
+
+	public StationResponse getSource() {
+		return source;
+	}
+
+	public StationResponse getTarget() {
+		return target;
+	}
 }

--- a/src/main/java/nextstep/subway/favorite/dto/FavoriteResponse.java
+++ b/src/main/java/nextstep/subway/favorite/dto/FavoriteResponse.java
@@ -1,5 +1,6 @@
 package nextstep.subway.favorite.dto;
 
+import nextstep.subway.favorite.domain.Favorite;
 import nextstep.subway.station.dto.StationResponse;
 
 public class FavoriteResponse {
@@ -14,6 +15,12 @@ public class FavoriteResponse {
 		this.id = id;
 		this.source = source;
 		this.target = target;
+	}
+
+	public static FavoriteResponse of(Favorite favorite) {
+		return new FavoriteResponse(favorite.getId()
+			, StationResponse.of(favorite.getSourceStation())
+			, StationResponse.of(favorite.getTargetStation()));
 	}
 
 	public Long getId() {

--- a/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
+++ b/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
@@ -16,6 +16,9 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import nextstep.subway.auth.domain.AuthenticationPrincipal;
+import nextstep.subway.auth.domain.LoginMember;
+import nextstep.subway.favorite.application.FavoriteService;
 import nextstep.subway.favorite.dto.FavoriteRequest;
 import nextstep.subway.favorite.dto.FavoriteResponse;
 import nextstep.subway.station.dto.StationResponse;
@@ -23,12 +26,17 @@ import nextstep.subway.station.dto.StationResponse;
 @RestController
 public class FavoriteController {
 
+	private FavoriteService favoriteService;
+
+	public FavoriteController(FavoriteService favoriteService) {
+		this.favoriteService = favoriteService;
+	}
+
 	@PostMapping("/favorites")
-	public ResponseEntity<FavoriteResponse> createStation(@RequestBody FavoriteRequest favoriteRequest) {
-		StationResponse upStation = new StationResponse(1L, "upStation", LocalDateTime.now(), LocalDateTime.now());
-		StationResponse downStation = new StationResponse(3L, "downStation", LocalDateTime.now(), LocalDateTime.now());
-		FavoriteResponse favoriteResponse = new FavoriteResponse(1L, upStation, downStation);
-		return ResponseEntity.created(URI.create("/favorites/" + 1L)).body(favoriteResponse);
+	public ResponseEntity<FavoriteResponse> createStation(@RequestBody FavoriteRequest favoriteRequest
+		, @AuthenticationPrincipal LoginMember loginMember) {
+		FavoriteResponse favorite = favoriteService.saveFavorite(favoriteRequest, loginMember.getId());
+		return ResponseEntity.created(URI.create("/favorites/" + favorite.getId())).body(favorite);
 	}
 
 	@GetMapping(value = "/favorites", produces = MediaType.APPLICATION_JSON_VALUE)

--- a/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
+++ b/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
@@ -1,0 +1,51 @@
+package nextstep.subway.favorite.ui;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.util.Arrays;
+import java.util.List;
+
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import nextstep.subway.favorite.dto.FavoriteRequest;
+import nextstep.subway.favorite.dto.FavoriteResponse;
+import nextstep.subway.station.dto.StationResponse;
+
+@RestController
+public class FavoriteController {
+
+	@PostMapping("/favorites")
+	public ResponseEntity<FavoriteResponse> createStation(@RequestBody FavoriteRequest favoriteRequest) {
+		StationResponse upStation = new StationResponse(1L, "upStation", LocalDateTime.now(), LocalDateTime.now());
+		StationResponse downStation = new StationResponse(3L, "downStation", LocalDateTime.now(), LocalDateTime.now());
+		FavoriteResponse favoriteResponse = new FavoriteResponse(1L, upStation, downStation);
+		return ResponseEntity.created(URI.create("/favorites/" + 1L)).body(favoriteResponse);
+	}
+
+	@GetMapping(value = "/favorites", produces = MediaType.APPLICATION_JSON_VALUE)
+	public ResponseEntity<List<FavoriteResponse>> showStations() {
+		StationResponse upStation = new StationResponse(1L, "upStation", LocalDateTime.now(), LocalDateTime.now());
+		StationResponse downStation = new StationResponse(3L, "downStation", LocalDateTime.now(), LocalDateTime.now());
+		FavoriteResponse favoriteResponse = new FavoriteResponse(1L, upStation, downStation);
+		return ResponseEntity.ok().body(Arrays.asList(favoriteResponse));
+	}
+
+	@DeleteMapping("/favorites/{id}")
+	public ResponseEntity deleteStation(@PathVariable Long id) {
+		return ResponseEntity.noContent().build();
+	}
+
+	@ExceptionHandler(DataIntegrityViolationException.class)
+	public ResponseEntity handleIllegalArgsException(DataIntegrityViolationException e) {
+		return ResponseEntity.badRequest().build();
+	}
+}

--- a/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
+++ b/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
@@ -38,12 +38,12 @@ public class FavoriteController {
 
 	@GetMapping(value = "/favorites", produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<List<FavoriteResponse>> showStations(@AuthenticationPrincipal LoginMember loginMember) {
-		List<FavoriteResponse> favorites = favoriteService.findAllFavoritesByMember(loginMember.getId());
-		return ResponseEntity.ok().body(favorites);
+		return ResponseEntity.ok().body(favoriteService.findAllFavoritesByMember(loginMember.getId()));
 	}
 
 	@DeleteMapping("/favorites/{id}")
-	public ResponseEntity deleteStation(@PathVariable Long id) {
+	public ResponseEntity deleteStation(@PathVariable Long id, @AuthenticationPrincipal LoginMember loginMember) {
+		favoriteService.removeFavoriteByIdAndMember(id, loginMember.getId());
 		return ResponseEntity.noContent().build();
 	}
 

--- a/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
+++ b/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
@@ -1,8 +1,6 @@
 package nextstep.subway.favorite.ui;
 
 import java.net.URI;
-import java.time.LocalDateTime;
-import java.util.Arrays;
 import java.util.List;
 
 import org.springframework.dao.DataIntegrityViolationException;
@@ -21,7 +19,6 @@ import nextstep.subway.auth.domain.LoginMember;
 import nextstep.subway.favorite.application.FavoriteService;
 import nextstep.subway.favorite.dto.FavoriteRequest;
 import nextstep.subway.favorite.dto.FavoriteResponse;
-import nextstep.subway.station.dto.StationResponse;
 
 @RestController
 public class FavoriteController {
@@ -40,11 +37,9 @@ public class FavoriteController {
 	}
 
 	@GetMapping(value = "/favorites", produces = MediaType.APPLICATION_JSON_VALUE)
-	public ResponseEntity<List<FavoriteResponse>> showStations() {
-		StationResponse upStation = new StationResponse(1L, "upStation", LocalDateTime.now(), LocalDateTime.now());
-		StationResponse downStation = new StationResponse(3L, "downStation", LocalDateTime.now(), LocalDateTime.now());
-		FavoriteResponse favoriteResponse = new FavoriteResponse(1L, upStation, downStation);
-		return ResponseEntity.ok().body(Arrays.asList(favoriteResponse));
+	public ResponseEntity<List<FavoriteResponse>> showStations(@AuthenticationPrincipal LoginMember loginMember) {
+		List<FavoriteResponse> favorites = favoriteService.findAllFavoritesByMember(loginMember.getId());
+		return ResponseEntity.ok().body(favorites);
 	}
 
 	@DeleteMapping("/favorites/{id}")

--- a/src/main/java/nextstep/subway/member/application/MemberService.java
+++ b/src/main/java/nextstep/subway/member/application/MemberService.java
@@ -5,7 +5,6 @@ import nextstep.subway.member.domain.MemberRepository;
 import nextstep.subway.member.dto.MemberRequest;
 import nextstep.subway.member.dto.MemberResponse;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 public class MemberService {
@@ -28,6 +27,7 @@ public class MemberService {
     public void updateMember(Long id, MemberRequest param) {
         Member member = memberRepository.findById(id).orElseThrow(RuntimeException::new);
         member.update(param.toMember());
+        memberRepository.save(member);
     }
 
     public void deleteMember(Long id) {

--- a/src/main/java/nextstep/subway/member/domain/Member.java
+++ b/src/main/java/nextstep/subway/member/domain/Member.java
@@ -51,7 +51,7 @@ public class Member extends BaseEntity {
 
     public void checkPassword(String password) {
         if (!StringUtils.equals(this.password, password)) {
-            throw new AuthorizationException();
+            throw new AuthorizationException("로그인 정보가 일치하지 않습니다.");
         }
     }
 }

--- a/src/main/java/nextstep/subway/member/ui/MemberController.java
+++ b/src/main/java/nextstep/subway/member/ui/MemberController.java
@@ -1,8 +1,8 @@
 package nextstep.subway.member.ui;
 
+import nextstep.subway.auth.application.AuthorizationException;
 import nextstep.subway.auth.domain.LoginMember;
 import nextstep.subway.auth.domain.AuthenticationPrincipal;
-import nextstep.subway.auth.domain.LoginMember;
 import nextstep.subway.member.application.MemberService;
 import nextstep.subway.member.dto.MemberRequest;
 import nextstep.subway.member.dto.MemberResponse;
@@ -44,20 +44,30 @@ public class MemberController {
     }
 
     @GetMapping("/members/me")
-    public ResponseEntity<MemberResponse> findMemberOfMine(LoginMember loginMember) {
+    public ResponseEntity<MemberResponse> findMemberOfMine(@AuthenticationPrincipal LoginMember loginMember) {
+        checkAuthorized(loginMember);
         MemberResponse member = memberService.findMember(loginMember.getId());
         return ResponseEntity.ok().body(member);
     }
 
     @PutMapping("/members/me")
-    public ResponseEntity<MemberResponse> updateMemberOfMine(LoginMember loginMember, @RequestBody MemberRequest param) {
+    public ResponseEntity<MemberResponse> updateMemberOfMine(@AuthenticationPrincipal LoginMember loginMember
+        , @RequestBody MemberRequest param) {
+        checkAuthorized(loginMember);
         memberService.updateMember(loginMember.getId(), param);
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/members/me")
-    public ResponseEntity<MemberResponse> deleteMemberOfMine(LoginMember loginMember) {
+    public ResponseEntity<MemberResponse> deleteMemberOfMine(@AuthenticationPrincipal LoginMember loginMember) {
+        checkAuthorized(loginMember);
         memberService.deleteMember(loginMember.getId());
         return ResponseEntity.noContent().build();
+    }
+
+    private void checkAuthorized(LoginMember loginMember) {
+        if (loginMember.getId() == null){
+            throw new AuthorizationException("유효하지 않은 인증 정보 입니다.");
+        }
     }
 }

--- a/src/main/java/nextstep/subway/member/ui/MemberController.java
+++ b/src/main/java/nextstep/subway/member/ui/MemberController.java
@@ -45,7 +45,6 @@ public class MemberController {
 
     @GetMapping("/members/me")
     public ResponseEntity<MemberResponse> findMemberOfMine(@AuthenticationPrincipal LoginMember loginMember) {
-        checkAuthorized(loginMember);
         MemberResponse member = memberService.findMember(loginMember.getId());
         return ResponseEntity.ok().body(member);
     }
@@ -53,21 +52,13 @@ public class MemberController {
     @PutMapping("/members/me")
     public ResponseEntity<MemberResponse> updateMemberOfMine(@AuthenticationPrincipal LoginMember loginMember
         , @RequestBody MemberRequest param) {
-        checkAuthorized(loginMember);
         memberService.updateMember(loginMember.getId(), param);
         return ResponseEntity.ok().build();
     }
 
     @DeleteMapping("/members/me")
     public ResponseEntity<MemberResponse> deleteMemberOfMine(@AuthenticationPrincipal LoginMember loginMember) {
-        checkAuthorized(loginMember);
         memberService.deleteMember(loginMember.getId());
         return ResponseEntity.noContent().build();
-    }
-
-    private void checkAuthorized(LoginMember loginMember) {
-        if (loginMember.getId() == null){
-            throw new AuthorizationException("유효하지 않은 인증 정보 입니다.");
-        }
     }
 }

--- a/src/main/java/nextstep/subway/path/domain/SubwayMap.java
+++ b/src/main/java/nextstep/subway/path/domain/SubwayMap.java
@@ -1,7 +1,9 @@
 package nextstep.subway.path.domain;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 import org.jgrapht.GraphPath;
 import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
@@ -46,8 +48,9 @@ public class SubwayMap {
 	}
 
 	public List<Section> allSections() {
-		List<Section> sections = new ArrayList<>();
-		lines.forEach(line -> sections.addAll(line.getSections()));
-		return sections;
+		return this.lines.stream()
+			.map(Line::getSections)
+			.flatMap(Collection::stream)
+			.collect(Collectors.toList());
 	}
 }

--- a/src/test/java/nextstep/subway/auth/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/auth/acceptance/AuthAcceptanceTest.java
@@ -61,14 +61,11 @@ public class AuthAcceptanceTest extends AcceptanceTest {
     @DisplayName("Bearer Auth 유효하지 않은 토큰")
     @Test
     void myInfoWithWrongBearerAuth() {
-        // given
-        ExtractableResponse<Response> createResponse = MemberAcceptanceTest.회원_등록_되어있음(EMAIL, PASSWORD, AGE);
-        로그인_요청(EMAIL, PASSWORD);
-        TokenResponse tokenResponse = new TokenResponse("WrongToken");
-
         //when
-        ExtractableResponse<Response> response = MemberAcceptanceTest.회원_정보_조회_요청_토큰(createResponse, tokenResponse);
-        MemberAcceptanceTest.회원_정보_조회됨(response, EMAIL, AGE);
+        ExtractableResponse<Response> response = MemberAcceptanceTest.내_정보_조회_요청(new TokenResponse("WrongToken"));
+
+        //then
+        토큰_인증_실패(response);
     }
 
     public static ExtractableResponse<Response> 로그인_요청 (String email, String password) {
@@ -94,7 +91,11 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
     }
 
-    public static TokenResponse 로그인_토큰_발급_되어있음 (String email, String password) {
+    public static void 토큰_인증_실패(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    public static TokenResponse 로그인_되어있음 (String email, String password) {
         return 로그인_요청(email, password).as(TokenResponse.class);
     }
 }

--- a/src/test/java/nextstep/subway/auth/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/auth/acceptance/AuthAcceptanceTest.java
@@ -1,24 +1,100 @@
 package nextstep.subway.auth.acceptance;
 
+import static org.assertj.core.api.Assertions.*;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
+import nextstep.subway.auth.dto.TokenRequest;
+import nextstep.subway.auth.dto.TokenResponse;
+import nextstep.subway.member.MemberAcceptanceTest;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 
 public class AuthAcceptanceTest extends AcceptanceTest {
+
+    public static final String EMAIL = "email@email.com";
+    public static final String PASSWORD = "password";
+    public static final int AGE = 20;
 
     @DisplayName("Bearer Auth")
     @Test
     void myInfoWithBearerAuth() {
+        //given
+        MemberAcceptanceTest.회원_등록_되어있음(EMAIL, PASSWORD, AGE);
+
+        // when
+        ExtractableResponse<Response> response = 로그인_요청(EMAIL, PASSWORD);
+
+        // then
+        로그인_됨(response);
+        로그인_토큰_발급_됨(response);
     }
 
-    @DisplayName("Bearer Auth 로그인 실패")
+    @DisplayName("Bearer Auth 로그인 실패 - 존재하지 않는 회원 이메일")
     @Test
-    void myInfoWithBadBearerAuth() {
+    void myInfoWithNotExistAuth() {
+        // when
+        ExtractableResponse<Response> response = 로그인_요청("notexist@email.com", PASSWORD);
+
+        // then
+        로그인_실패(response);
+    }
+
+    @DisplayName("Bearer Auth 로그인 실패 - 틀린 비밀번호")
+    @Test
+    void myInfoWithWrongPasswordAuth() {
+        //given
+        MemberAcceptanceTest.회원_등록_되어있음(EMAIL, PASSWORD, AGE);
+
+        // when
+        ExtractableResponse<Response> response = 로그인_요청(EMAIL,  "Wrong" + PASSWORD);
+
+        // then
+        로그인_실패(response);
     }
 
     @DisplayName("Bearer Auth 유효하지 않은 토큰")
     @Test
     void myInfoWithWrongBearerAuth() {
+        // given
+        ExtractableResponse<Response> createResponse = MemberAcceptanceTest.회원_등록_되어있음(EMAIL, PASSWORD, AGE);
+        로그인_요청(EMAIL, PASSWORD);
+        TokenResponse tokenResponse = new TokenResponse("WrongToken");
+
+        //when
+        ExtractableResponse<Response> response = MemberAcceptanceTest.회원_정보_조회_요청_토큰(createResponse, tokenResponse);
+        MemberAcceptanceTest.회원_정보_조회됨(response, EMAIL, AGE);
     }
 
+    public static ExtractableResponse<Response> 로그인_요청 (String email, String password) {
+        TokenRequest request = new TokenRequest(email, password);
+
+        return RestAssured.given().log().all()
+            .body(request)
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .when().post("/login/token")
+            .then().log().all().extract();
+    }
+
+    public static void 로그인_됨 (ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    public static void 로그인_토큰_발급_됨 (ExtractableResponse<Response> response) {
+        TokenResponse tokenResponse = response.as(TokenResponse.class);
+        assertThat(tokenResponse.getAccessToken()).isNotBlank();
+    }
+
+    public static void 로그인_실패(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    public static TokenResponse 로그인_토큰_발급_되어있음 (String email, String password) {
+        return 로그인_요청(email, password).as(TokenResponse.class);
+    }
 }

--- a/src/test/java/nextstep/subway/auth/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/auth/acceptance/AuthAcceptanceTest.java
@@ -95,7 +95,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
     }
 
-    public static TokenResponse 로그인_되어있음 (String email, String password) {
-        return 로그인_요청(email, password).as(TokenResponse.class);
+    public static ExtractableResponse<Response> 로그인_되어있음 (String email, String password) {
+        return 로그인_요청(email, password);
     }
 }

--- a/src/test/java/nextstep/subway/favorite/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/favorite/FavoriteAcceptanceTest.java
@@ -1,8 +1,129 @@
 package nextstep.subway.favorite;
 
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
+import nextstep.subway.auth.acceptance.AuthAcceptanceTest;
+import nextstep.subway.auth.dto.TokenResponse;
+import nextstep.subway.favorite.dto.FavoriteRequest;
+import nextstep.subway.favorite.dto.FavoriteResponse;
+import nextstep.subway.line.acceptance.LineAcceptanceTest;
+import nextstep.subway.line.acceptance.LineSectionAcceptanceTest;
+import nextstep.subway.line.dto.LineResponse;
+import nextstep.subway.member.MemberAcceptanceTest;
+import nextstep.subway.station.StationAcceptanceTest;
+import nextstep.subway.station.dto.StationResponse;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 
 @DisplayName("즐겨찾기 관련 기능")
 public class FavoriteAcceptanceTest extends AcceptanceTest {
+
+	public static final String EMAIL = "email@email.com";
+	public static final String PASSWORD = "password";
+
+	private StationResponse upStation;
+	private StationResponse middleStation;
+	private StationResponse downStation;
+	private LineResponse line;
+	private TokenResponse tokenResponse;
+
+	@BeforeEach
+	public void setUp() {
+		super.setUp();
+		upStation = StationAcceptanceTest.지하철역_등록되어_있음("문래역").as(StationResponse.class);
+		middleStation = StationAcceptanceTest.지하철역_등록되어_있음("사당역").as(StationResponse.class);
+		downStation = StationAcceptanceTest.지하철역_등록되어_있음("잠실역").as(StationResponse.class);
+		line = LineAcceptanceTest.지하철_노선_등록되어_있음("2호선", "green", upStation, downStation, 10)
+			.as(LineResponse.class);
+		LineSectionAcceptanceTest.지하철_노선에_지하철역_등록되어_있음(line, middleStation, downStation, 4);
+		MemberAcceptanceTest.회원_등록_되어있음(EMAIL, PASSWORD, 20);
+		tokenResponse = AuthAcceptanceTest.로그인_되어있음(EMAIL, PASSWORD).as(TokenResponse.class);
+	}
+
+	@Test
+	@DisplayName("즐겨찾기를 관리한다.")
+	void favorite() {
+		//when
+		ExtractableResponse<Response> createResponse = 즐겨찾기_생성_요청(upStation, downStation, tokenResponse);
+		//then
+		즐겨찾기_생성됨(createResponse);
+
+		//when
+		ExtractableResponse<Response> findAllResponse = 즐겨찾기_목록_조회_요청(tokenResponse);
+		//then
+		즐겨찾기_목록_응답됨(findAllResponse);
+		즐겨찾기_목록_포함됨(findAllResponse, Arrays.asList(createResponse));
+
+		//when
+		ExtractableResponse<Response> deleteResponse = 즐겨찾기_삭제_요청(createResponse, tokenResponse);
+		//then
+		즐겨찾기_삭제됨(deleteResponse);
+	}
+
+	public static ExtractableResponse<Response> 즐겨찾기_생성_요청(StationResponse source, StationResponse target, TokenResponse tokenResponse) {
+		FavoriteRequest favoriteRequest = new FavoriteRequest(source.getId(), target.getId());
+
+		return RestAssured.given().log().all()
+			.auth().oauth2(tokenResponse.getAccessToken())
+			.contentType(MediaType.APPLICATION_JSON_VALUE)
+			.body(favoriteRequest)
+			.when().post("/favorites")
+			.then().log().all()
+			.extract();
+	}
+
+	public static ExtractableResponse<Response> 즐겨찾기_목록_조회_요청(TokenResponse tokenResponse) {
+		return RestAssured.given().log().all()
+			.auth().oauth2(tokenResponse.getAccessToken())
+			.accept(MediaType.APPLICATION_JSON_VALUE)
+			.when().get("/favorites")
+			.then().log().all()
+			.extract();
+	}
+
+	public static ExtractableResponse<Response> 즐겨찾기_삭제_요청(ExtractableResponse<Response> response, TokenResponse tokenResponse) {
+		String uri = response.header("Location");
+
+		return RestAssured.given().log().all()
+			.auth().oauth2(tokenResponse.getAccessToken())
+			.when().delete(uri)
+			.then().log().all()
+			.extract();
+	}
+
+	public static void 즐겨찾기_생성됨(ExtractableResponse<Response> response) {
+		assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+	}
+
+	public static void 즐겨찾기_목록_응답됨(ExtractableResponse<Response> response) {
+		assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+	}
+
+	public static void 즐겨찾기_목록_포함됨(ExtractableResponse<Response> response, List<ExtractableResponse<Response>> createdResponses) {
+		List<Long> expectedFavoriteIds = createdResponses.stream()
+			.map(it -> Long.parseLong(it.header("Location").split("/")[2]))
+			.collect(Collectors.toList());
+
+		List<Long> resultFavoriteIds = response.jsonPath().getList(".", FavoriteResponse.class).stream()
+			.map(FavoriteResponse::getId)
+			.collect(Collectors.toList());
+
+		assertThat(resultFavoriteIds).containsAll(expectedFavoriteIds);
+	}
+
+	public static void 즐겨찾기_삭제됨(ExtractableResponse<Response> response) {
+		assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+	}
 }

--- a/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
@@ -52,7 +52,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     void manageMyInfo() {
         //given
         회원_등록_되어있음(EMAIL, PASSWORD, AGE);
-        TokenResponse tokenResponse = AuthAcceptanceTest.로그인_되어있음(EMAIL, PASSWORD);
+        TokenResponse tokenResponse = AuthAcceptanceTest.로그인_되어있음(EMAIL, PASSWORD).as(TokenResponse.class);
         // when
         ExtractableResponse<Response> findResponse = 내_정보_조회_요청(tokenResponse);
         // then
@@ -69,7 +69,7 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         AuthAcceptanceTest.토큰_인증_실패(findResponseAfterUpdate);
 
         //given
-        TokenResponse tokenResponseReLogin = AuthAcceptanceTest.로그인_되어있음(NEW_EMAIL, NEW_PASSWORD);
+        TokenResponse tokenResponseReLogin = AuthAcceptanceTest.로그인_되어있음(NEW_EMAIL, NEW_PASSWORD).as(TokenResponse.class);
         // when
         ExtractableResponse<Response> deleteResponse = 내_정보_삭제_요청(tokenResponseReLogin);
         // then

--- a/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
@@ -4,6 +4,7 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
+import nextstep.subway.auth.acceptance.AuthAcceptanceTest;
 import nextstep.subway.auth.dto.TokenResponse;
 import nextstep.subway.member.dto.MemberRequest;
 import nextstep.subway.member.dto.MemberResponse;
@@ -49,7 +50,35 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     @DisplayName("나의 정보를 관리한다.")
     @Test
     void manageMyInfo() {
+        //given
+        회원_등록_되어있음(EMAIL, PASSWORD, AGE);
+        TokenResponse tokenResponse = AuthAcceptanceTest.로그인_되어있음(EMAIL, PASSWORD);
+        // when
+        ExtractableResponse<Response> findResponse = 내_정보_조회_요청(tokenResponse);
+        // then
+        회원_정보_조회됨(findResponse, EMAIL, AGE);
 
+        // when
+        ExtractableResponse<Response> updateResponse = 내_정보_수정_요청(tokenResponse, NEW_EMAIL, NEW_PASSWORD, NEW_AGE);
+        // then
+        회원_정보_수정됨(updateResponse);
+
+        // when
+        ExtractableResponse<Response> findResponseAfterUpdate = 내_정보_조회_요청(tokenResponse);
+        // then
+        AuthAcceptanceTest.토큰_인증_실패(findResponseAfterUpdate);
+
+        //given
+        TokenResponse tokenResponseReLogin = AuthAcceptanceTest.로그인_되어있음(NEW_EMAIL, NEW_PASSWORD);
+        // when
+        ExtractableResponse<Response> deleteResponse = 내_정보_삭제_요청(tokenResponseReLogin);
+        // then
+        회원_삭제됨(deleteResponse);
+
+        // when
+        ExtractableResponse<Response> findResponseAfterDelete = 내_정보_조회_요청(tokenResponse);
+        // then
+        AuthAcceptanceTest.토큰_인증_실패(findResponseAfterDelete);
     }
 
     public static ExtractableResponse<Response> 회원_생성을_요청(String email, String password, Integer age) {
@@ -75,14 +104,11 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> 회원_정보_조회_요청_토큰(ExtractableResponse<Response> response, TokenResponse tokenResponse) {
-        String uri = response.header("Location");
-
-        return RestAssured
-            .given().log().all()
-            .auth().oauth2(tokenResponse.getAccessToken())
+    public static ExtractableResponse<Response> 내_정보_조회_요청(TokenResponse response) {
+        return RestAssured.given().log().all()
+            .auth().oauth2(response.getAccessToken())
             .accept(MediaType.APPLICATION_JSON_VALUE)
-            .when().get(uri)
+            .when().get("/members/me")
             .then().log().all()
             .extract();
     }
@@ -100,6 +126,18 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .extract();
     }
 
+    public static ExtractableResponse<Response> 내_정보_수정_요청(TokenResponse response, String email, String password, Integer age) {
+        MemberRequest memberRequest = new MemberRequest(email, password, age);
+
+        return RestAssured.given().log().all()
+            .auth().oauth2(response.getAccessToken())
+            .contentType(MediaType.APPLICATION_JSON_VALUE)
+            .body(memberRequest)
+            .when().put("/members/me")
+            .then().log().all()
+            .extract();
+    }
+
     public static ExtractableResponse<Response> 회원_삭제_요청(ExtractableResponse<Response> response) {
         String uri = response.header("Location");
         return RestAssured
@@ -107,6 +145,14 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .when().delete(uri)
                 .then().log().all()
                 .extract();
+    }
+
+    public static ExtractableResponse<Response> 내_정보_삭제_요청(TokenResponse response) {
+        return RestAssured.given().log().all()
+            .auth().oauth2(response.getAccessToken())
+            .when().delete("/members/me")
+            .then().log().all()
+            .extract();
     }
 
     public static void 회원_생성됨(ExtractableResponse<Response> response) {

--- a/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
@@ -4,6 +4,7 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
+import nextstep.subway.auth.dto.TokenResponse;
 import nextstep.subway.member.dto.MemberRequest;
 import nextstep.subway.member.dto.MemberResponse;
 import org.junit.jupiter.api.DisplayName;
@@ -74,6 +75,18 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .extract();
     }
 
+    public static ExtractableResponse<Response> 회원_정보_조회_요청_토큰(ExtractableResponse<Response> response, TokenResponse tokenResponse) {
+        String uri = response.header("Location");
+
+        return RestAssured
+            .given().log().all()
+            .auth().oauth2(tokenResponse.getAccessToken())
+            .accept(MediaType.APPLICATION_JSON_VALUE)
+            .when().get(uri)
+            .then().log().all()
+            .extract();
+    }
+
     public static ExtractableResponse<Response> 회원_정보_수정_요청(ExtractableResponse<Response> response, String email, String password, Integer age) {
         String uri = response.header("Location");
         MemberRequest memberRequest = new MemberRequest(email, password, age);
@@ -113,5 +126,9 @@ public class MemberAcceptanceTest extends AcceptanceTest {
 
     public static void 회원_삭제됨(ExtractableResponse<Response> response) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
+    }
+
+    public static ExtractableResponse<Response> 회원_등록_되어있음(String email, String password, Integer age) {
+        return 회원_생성을_요청(email, password, age);
     }
 }


### PR DESCRIPTION
안녕하세요 : )
지난 미션에서 힌트 주셨던대로 StreamAPI flatMap 적용해보았습니다 
SubwayMap 도메인에서 외부라이브러리 주입받는 건 다음 미션이 또 경로랑 관련이 있는 것 같아서 다음 미션에서 더 고민해보겠습니다 

MemberService에서 인수테스트를 통합으로 작성하였는데 처음엔 아래와 같은 흐름이었습니다.
```
내정보 조회 -> 조회됨 -> 내정보 수정 -> 수정됨 -> 내정보 삭제 -> 삭제됨
```
이메일을 키처럼 사용하고 있는데, 이메일 자체도 변경할 수 있도록 되어있어서 이메일이 변경되면 인증이 실패하더라구요 
이메일을 변경하지 못하도록 update 로직을 수정했다가, 
기존 로직을 손대지 않고 해보자 ! 해서 아래와 같은 시나리오로 변경해서 테스트했습니다.
작성하고 나니, 중간에 다시 로그인을 하는 부분을 기점으로 테스트를 분리하는게 맞았을까 ? 하는 생각이 들었습니다.

```
내정보 조회 -> 조회됨 -> 내정보 수정 -> 수정됨 -> 내정보 조회 -> 이메일 변경되어 토큰 인증 실패
-> 재 로그인 -> 내정보 삭제 -> 내 정보 조회 -> 내 정보 삭제되어 토큰 인증 실패
```

코멘트 주시면 또 열심히 고민해보겠습니다 감사합니다! :)