### PR TITLE
Step2 - 경로 조회 기능

### DIFF
--- a/src/main/java/nextstep/subway/line/domain/Line.java
+++ b/src/main/java/nextstep/subway/line/domain/Line.java
@@ -2,11 +2,9 @@ package nextstep.subway.line.domain;
 
 import nextstep.subway.BaseEntity;
 import nextstep.subway.station.domain.Station;
-import nextstep.subway.station.dto.StationResponse;
 
 import javax.persistence.*;
 import java.util.*;
-import java.util.stream.Collectors;
 
 @Entity
 public class Line extends BaseEntity {
@@ -53,12 +51,6 @@ public class Line extends BaseEntity {
 
     public List<Section> getSections() {
         return sections.getSections();
-    }
-
-    public List<StationResponse> getStationsAsResponse() {
-        return getStations().stream()
-                .map(StationResponse::of)
-                .collect(Collectors.toList());
     }
 
     public List<Station> getStations() {

--- a/src/main/java/nextstep/subway/line/dto/LineResponse.java
+++ b/src/main/java/nextstep/subway/line/dto/LineResponse.java
@@ -5,6 +5,7 @@ import nextstep.subway.station.dto.StationResponse;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 
 public class LineResponse {
     private Long id;
@@ -27,7 +28,13 @@ public class LineResponse {
     }
 
     public static LineResponse of(Line line) {
-        return new LineResponse(line.getId(), line.getName(), line.getColor(), line.getStationsAsResponse(), line.getCreatedDate(), line.getModifiedDate());
+        return new LineResponse(line.getId(), line.getName(), line.getColor(), getStationsResponses(line), line.getCreatedDate(), line.getModifiedDate());
+    }
+
+    private static List<StationResponse> getStationsResponses(Line line) {
+        return line.getStations().stream()
+                .map(StationResponse::of)
+                .collect(Collectors.toList());
     }
 
     public Long getId() {

--- a/src/main/java/nextstep/subway/path/application/PathService.java
+++ b/src/main/java/nextstep/subway/path/application/PathService.java
@@ -30,11 +30,10 @@ public class PathService {
         List<Line> lines = lineRepository.findAll();
         Station source = findStation(pathRequest.getSource());
         Station target = findStation(pathRequest.getTarget());
-        SubwayMapData subwayMapData = new SubwayMapData(lines, SectionEdge.class);
-        SubwayNavigation subwayNavigation = new SubwayNavigation(subwayMapData.initData());
+        SubwayNavigation subwayNavigation = new SubwayNavigation(new SubwayMapData(lines, SectionEdge.class).initData());
 
         return PathResponse.of(subwayNavigation.getPaths(source, target),
-                (int)subwayNavigation.getDistance(source, target));
+                subwayNavigation.getDistance(source, target));
     }
 
     private Station findStation(Long id) {

--- a/src/main/java/nextstep/subway/path/application/PathService.java
+++ b/src/main/java/nextstep/subway/path/application/PathService.java
@@ -4,12 +4,12 @@ import nextstep.subway.line.domain.Line;
 import nextstep.subway.line.domain.LineRepository;
 import nextstep.subway.path.domain.SectionEdge;
 import nextstep.subway.path.domain.SubwayMapData;
+import nextstep.subway.path.domain.SubwayNavigation;
 import nextstep.subway.path.dto.PathRequest;
 import nextstep.subway.path.dto.PathResponse;
 import nextstep.subway.station.domain.Station;
 import nextstep.subway.station.domain.StationRepository;
 
-import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -31,10 +31,10 @@ public class PathService {
         Station source = findStation(pathRequest.getSource());
         Station target = findStation(pathRequest.getTarget());
         SubwayMapData subwayMapData = new SubwayMapData(lines, SectionEdge.class);
-        DijkstraShortestPath dijkstraShortestPath = new DijkstraShortestPath(subwayMapData.initData());
+        SubwayNavigation subwayNavigation = new SubwayNavigation(subwayMapData.initData());
 
-        return PathResponse.of(dijkstraShortestPath.getPath(source, target).getVertexList(),
-                (int)dijkstraShortestPath.getPathWeight(source, target));
+        return PathResponse.of(subwayNavigation.getPaths(source, target),
+                (int)subwayNavigation.getDistance(source, target));
     }
 
     private Station findStation(Long id) {

--- a/src/main/java/nextstep/subway/path/application/PathService.java
+++ b/src/main/java/nextstep/subway/path/application/PathService.java
@@ -1,0 +1,56 @@
+package nextstep.subway.path.application;
+
+import nextstep.subway.line.domain.Line;
+import nextstep.subway.line.domain.LineRepository;
+import nextstep.subway.path.dto.PathRequest;
+import nextstep.subway.path.dto.PathResponse;
+import nextstep.subway.station.domain.Station;
+import nextstep.subway.station.domain.StationRepository;
+
+import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.WeightedMultigraph;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.stream.Collectors;
+
+@Service
+public class PathService {
+
+    private LineRepository lineRepository;
+    private StationRepository stationRepository;
+
+    public PathService(LineRepository lineRepository, StationRepository stationRepository) {
+        this.lineRepository = lineRepository;
+        this.stationRepository = stationRepository;
+    }
+
+    public PathResponse findShortestPath(PathRequest pathRequest) {
+        List<Line> lines = lineRepository.findAll();
+        Station source = findStation(pathRequest.getSource());
+        Station target = findStation(pathRequest.getTarget());
+        WeightedMultigraph<Station, DefaultWeightedEdge> graph
+                = new WeightedMultigraph(DefaultWeightedEdge.class);
+
+        lines.stream()
+             .flatMap(line -> line.getStations().stream())
+             .collect(Collectors.toSet())
+             .forEach(graph::addVertex);
+
+        lines.stream()
+             .flatMap(line -> line.getSections().stream())
+             .forEach(section ->
+                 graph.setEdgeWeight(graph.addEdge(section.getUpStation(), section.getDownStation()), section.getDistance())
+             );
+        DijkstraShortestPath dijkstraShortestPath = new DijkstraShortestPath(graph);
+
+        return PathResponse.of(dijkstraShortestPath.getPath(source, target).getVertexList(),
+                (int)dijkstraShortestPath.getPathWeight(source, target));
+    }
+
+    private Station findStation(Long id) {
+        return stationRepository.findById(id).orElseThrow(NoSuchElementException::new);
+    }
+}

--- a/src/main/java/nextstep/subway/path/application/PathService.java
+++ b/src/main/java/nextstep/subway/path/application/PathService.java
@@ -2,6 +2,7 @@ package nextstep.subway.path.application;
 
 import nextstep.subway.line.domain.Line;
 import nextstep.subway.line.domain.LineRepository;
+import nextstep.subway.path.domain.SectionEdge;
 import nextstep.subway.path.domain.SubwayMapData;
 import nextstep.subway.path.dto.PathRequest;
 import nextstep.subway.path.dto.PathResponse;
@@ -9,7 +10,6 @@ import nextstep.subway.station.domain.Station;
 import nextstep.subway.station.domain.StationRepository;
 
 import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
-import org.jgrapht.graph.DefaultWeightedEdge;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -30,7 +30,7 @@ public class PathService {
         List<Line> lines = lineRepository.findAll();
         Station source = findStation(pathRequest.getSource());
         Station target = findStation(pathRequest.getTarget());
-        SubwayMapData subwayMapData = new SubwayMapData(lines, DefaultWeightedEdge.class);
+        SubwayMapData subwayMapData = new SubwayMapData(lines, SectionEdge.class);
         DijkstraShortestPath dijkstraShortestPath = new DijkstraShortestPath(subwayMapData.initData());
 
         return PathResponse.of(dijkstraShortestPath.getPath(source, target).getVertexList(),

--- a/src/main/java/nextstep/subway/path/domain/SectionEdge.java
+++ b/src/main/java/nextstep/subway/path/domain/SectionEdge.java
@@ -1,0 +1,18 @@
+package nextstep.subway.path.domain;
+
+import nextstep.subway.line.domain.Section;
+import org.jgrapht.graph.DefaultWeightedEdge;
+
+public class SectionEdge extends DefaultWeightedEdge {
+
+    private final Section section;
+
+    public SectionEdge(Section section) {
+        this.section = section;
+    }
+
+    @Override
+    protected double getWeight() {
+        return section.getDistance();
+    }
+}

--- a/src/main/java/nextstep/subway/path/domain/SubwayMapData.java
+++ b/src/main/java/nextstep/subway/path/domain/SubwayMapData.java
@@ -1,0 +1,43 @@
+package nextstep.subway.path.domain;
+
+import nextstep.subway.line.domain.Line;
+import nextstep.subway.station.domain.Station;
+import org.jgrapht.WeightedGraph;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.jgrapht.graph.WeightedMultigraph;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class SubwayMapData extends WeightedMultigraph<Station, DefaultWeightedEdge> {
+    private final List<Line> lines;
+
+    public SubwayMapData(List<Line> lines, Class<DefaultWeightedEdge> edgeClass) {
+        super(edgeClass);
+        this.lines = Collections.unmodifiableList(lines);
+    }
+
+    public WeightedGraph initData() {
+        initVertex();
+        initEdgeWeight();
+        return this;
+    }
+
+    private void initVertex() {
+        lines.stream()
+                .flatMap(line -> line.getStations().stream())
+                .collect(Collectors.toSet())
+                .forEach(this::addVertex);
+    }
+
+    private void initEdgeWeight() {
+        lines.stream()
+             .flatMap(line -> line.getSections().stream())
+             .forEach(section -> {
+                 SectionEdge sectionEdge = new SectionEdge(section);
+                 addEdge(section.getUpStation(), section.getDownStation(), sectionEdge);
+                 setEdgeWeight(sectionEdge, section.getDistance());
+             });
+    }
+}

--- a/src/main/java/nextstep/subway/path/domain/SubwayMapData.java
+++ b/src/main/java/nextstep/subway/path/domain/SubwayMapData.java
@@ -3,19 +3,18 @@ package nextstep.subway.path.domain;
 import nextstep.subway.line.domain.Line;
 import nextstep.subway.station.domain.Station;
 import org.jgrapht.WeightedGraph;
-import org.jgrapht.graph.DefaultWeightedEdge;
 import org.jgrapht.graph.WeightedMultigraph;
 
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 
-public class SubwayMapData extends WeightedMultigraph<Station, DefaultWeightedEdge> {
+public class SubwayMapData extends WeightedMultigraph<Station, SectionEdge> {
     private static final String NO_LINES_EXCEPTION = "경로 조회에 필요한 노선도 값이 조회되지 않습니다.";
 
     private final List<Line> lines;
 
-    public SubwayMapData(List<Line> lines, Class<DefaultWeightedEdge> edgeClass) {
+    public SubwayMapData(List<Line> lines, Class<SectionEdge> edgeClass) {
         super(edgeClass);
         validateLines(lines);
         this.lines = Collections.unmodifiableList(lines);

--- a/src/main/java/nextstep/subway/path/domain/SubwayMapData.java
+++ b/src/main/java/nextstep/subway/path/domain/SubwayMapData.java
@@ -11,11 +11,20 @@ import java.util.List;
 import java.util.stream.Collectors;
 
 public class SubwayMapData extends WeightedMultigraph<Station, DefaultWeightedEdge> {
+    private static final String NO_LINES_EXCEPTION = "경로 조회에 필요한 노선도 값이 조회되지 않습니다.";
+
     private final List<Line> lines;
 
     public SubwayMapData(List<Line> lines, Class<DefaultWeightedEdge> edgeClass) {
         super(edgeClass);
+        validateLines(lines);
         this.lines = Collections.unmodifiableList(lines);
+    }
+
+    private void validateLines(List<Line> lines) {
+        if (lines.isEmpty()) {
+            throw new IllegalArgumentException(NO_LINES_EXCEPTION);
+        }
     }
 
     public WeightedGraph initData() {

--- a/src/main/java/nextstep/subway/path/domain/SubwayNavigation.java
+++ b/src/main/java/nextstep/subway/path/domain/SubwayNavigation.java
@@ -13,15 +13,16 @@ import java.util.Objects;
 public class SubwayNavigation {
     private static final String EQUAL_STATION_EXCEPTION = "같은 역으로 경로를 조회할 수 없습니다.";
     private static final String DISCONNECT_STATION_EXCEPTION = "노선이 연결되어 있지 않습니다.";
+    private static final String UNKNOWN_STATION_EXCEPTION = "기존에 등록되지 않은 역입니다.";
 
     private final ShortestPathAlgorithm<Station, SectionEdge> shortestPath;
 
     public SubwayNavigation(WeightedGraph graph) {
-
         this.shortestPath = new DijkstraShortestPath<>(graph);
     }
 
     public List<Station> getPaths(Station source, Station target) {
+        validateUnknownStaton(source, target);
         validateEqualStation(source, target);
         GraphPath<Station, SectionEdge> path = shortestPath.getPath(source, target);
         validatePath(path);
@@ -37,6 +38,12 @@ public class SubwayNavigation {
     private void validatePath(GraphPath<Station, SectionEdge> path) {
         if (Objects.isNull(path)) {
             throw new IllegalArgumentException(DISCONNECT_STATION_EXCEPTION);
+        }
+    }
+
+    private void validateUnknownStaton(Station source, Station target) {
+        if (Objects.isNull(source) || Objects.isNull(target)) {
+            throw new IllegalArgumentException(UNKNOWN_STATION_EXCEPTION);
         }
     }
 

--- a/src/main/java/nextstep/subway/path/domain/SubwayNavigation.java
+++ b/src/main/java/nextstep/subway/path/domain/SubwayNavigation.java
@@ -1,0 +1,25 @@
+package nextstep.subway.path.domain;
+
+import nextstep.subway.station.domain.Station;
+import org.jgrapht.WeightedGraph;
+import org.jgrapht.alg.interfaces.ShortestPathAlgorithm;
+import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
+
+import java.math.BigDecimal;
+import java.util.List;
+
+public class SubwayNavigation {
+    private final ShortestPathAlgorithm<Station, SectionEdge> shortestPath;
+
+    public SubwayNavigation(WeightedGraph graph) {
+        this.shortestPath = new DijkstraShortestPath<>(graph);
+    }
+
+    public List<Station> getPaths(Station source, Station target) {
+        return shortestPath.getPath(source, target).getVertexList();
+    }
+
+    public int getDistance(Station source, Station target) {
+        return new BigDecimal(shortestPath.getPathWeight(source, target)).intValue();
+    }
+}

--- a/src/main/java/nextstep/subway/path/domain/SubwayNavigation.java
+++ b/src/main/java/nextstep/subway/path/domain/SubwayNavigation.java
@@ -14,11 +14,19 @@ public class SubwayNavigation {
     private static final String EQUAL_STATION_EXCEPTION = "같은 역으로 경로를 조회할 수 없습니다.";
     private static final String DISCONNECT_STATION_EXCEPTION = "노선이 연결되어 있지 않습니다.";
     private static final String UNKNOWN_STATION_EXCEPTION = "기존에 등록되지 않은 역입니다.";
+    private static final String NO_GRAPH_EXCEPTION = "경로 조회를 위한 객체 그래프 값이 없습니다.";
 
     private final ShortestPathAlgorithm<Station, SectionEdge> shortestPath;
 
     public SubwayNavigation(WeightedGraph graph) {
+        validateGraph(graph);
         this.shortestPath = new DijkstraShortestPath<>(graph);
+    }
+
+    private void validateGraph(WeightedGraph graph) {
+        if (Objects.isNull(graph)) {
+            throw new IllegalArgumentException(NO_GRAPH_EXCEPTION);
+        }
     }
 
     public List<Station> getPaths(Station source, Station target) {

--- a/src/main/java/nextstep/subway/path/domain/SubwayNavigation.java
+++ b/src/main/java/nextstep/subway/path/domain/SubwayNavigation.java
@@ -9,14 +9,24 @@ import java.math.BigDecimal;
 import java.util.List;
 
 public class SubwayNavigation {
+    private static final String EQUAL_STATION_EXCEPTION = "같은 역으로 경로를 조회할 수 없습니다.";
+
     private final ShortestPathAlgorithm<Station, SectionEdge> shortestPath;
 
     public SubwayNavigation(WeightedGraph graph) {
+
         this.shortestPath = new DijkstraShortestPath<>(graph);
     }
 
     public List<Station> getPaths(Station source, Station target) {
+        validateEqualStation(source, target);
         return shortestPath.getPath(source, target).getVertexList();
+    }
+
+    private void validateEqualStation(Station source, Station target) {
+        if (source.equals(target)) {
+            throw new IllegalArgumentException(EQUAL_STATION_EXCEPTION);
+        }
     }
 
     public int getDistance(Station source, Station target) {

--- a/src/main/java/nextstep/subway/path/domain/SubwayNavigation.java
+++ b/src/main/java/nextstep/subway/path/domain/SubwayNavigation.java
@@ -1,15 +1,18 @@
 package nextstep.subway.path.domain;
 
 import nextstep.subway.station.domain.Station;
+import org.jgrapht.GraphPath;
 import org.jgrapht.WeightedGraph;
 import org.jgrapht.alg.interfaces.ShortestPathAlgorithm;
 import org.jgrapht.alg.shortestpath.DijkstraShortestPath;
 
 import java.math.BigDecimal;
 import java.util.List;
+import java.util.Objects;
 
 public class SubwayNavigation {
     private static final String EQUAL_STATION_EXCEPTION = "같은 역으로 경로를 조회할 수 없습니다.";
+    private static final String DISCONNECT_STATION_EXCEPTION = "노선이 연결되어 있지 않습니다.";
 
     private final ShortestPathAlgorithm<Station, SectionEdge> shortestPath;
 
@@ -20,7 +23,9 @@ public class SubwayNavigation {
 
     public List<Station> getPaths(Station source, Station target) {
         validateEqualStation(source, target);
-        return shortestPath.getPath(source, target).getVertexList();
+        GraphPath<Station, SectionEdge> path = shortestPath.getPath(source, target);
+        validatePath(path);
+        return path.getVertexList();
     }
 
     private void validateEqualStation(Station source, Station target) {
@@ -29,7 +34,13 @@ public class SubwayNavigation {
         }
     }
 
+    private void validatePath(GraphPath<Station, SectionEdge> path) {
+        if (Objects.isNull(path)) {
+            throw new IllegalArgumentException(DISCONNECT_STATION_EXCEPTION);
+        }
+    }
+
     public int getDistance(Station source, Station target) {
-        return new BigDecimal(shortestPath.getPathWeight(source, target)).intValue();
+        return BigDecimal.valueOf(shortestPath.getPathWeight(source, target)).intValue();
     }
 }

--- a/src/main/java/nextstep/subway/path/dto/PathRequest.java
+++ b/src/main/java/nextstep/subway/path/dto/PathRequest.java
@@ -1,0 +1,19 @@
+package nextstep.subway.path.dto;
+
+public class PathRequest {
+    private Long source;
+    private Long target;
+
+    public PathRequest(Long source, Long target) {
+        this.source = source;
+        this.target = target;
+    }
+
+    public Long getSource() {
+        return source;
+    }
+
+    public Long getTarget() {
+        return target;
+    }
+}

--- a/src/main/java/nextstep/subway/path/dto/PathResponse.java
+++ b/src/main/java/nextstep/subway/path/dto/PathResponse.java
@@ -1,0 +1,28 @@
+package nextstep.subway.path.dto;
+
+import nextstep.subway.station.domain.Station;
+
+import java.util.List;
+
+public class PathResponse {
+
+    private final List<Station> stations;
+    private final int distance;
+
+    public PathResponse(List<Station> stations, int distance) {
+        this.stations = stations;
+        this.distance = distance;
+    }
+
+    public static PathResponse of(List<Station> stations, int distance) {
+        return new PathResponse(stations, distance);
+    }
+
+    public List<Station> getStations() {
+        return stations;
+    }
+
+    public int getDistance() {
+        return distance;
+    }
+}

--- a/src/main/java/nextstep/subway/path/ui/PathController.java
+++ b/src/main/java/nextstep/subway/path/ui/PathController.java
@@ -1,0 +1,16 @@
+package nextstep.subway.path.ui;
+
+import nextstep.subway.path.dto.PathRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class PathController {
+
+    @GetMapping("/paths")
+    public ResponseEntity getPaths(@ModelAttribute PathRequest pathRequest) {
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/nextstep/subway/path/ui/PathController.java
+++ b/src/main/java/nextstep/subway/path/ui/PathController.java
@@ -1,6 +1,8 @@
 package nextstep.subway.path.ui;
 
+import nextstep.subway.path.application.PathService;
 import nextstep.subway.path.dto.PathRequest;
+import nextstep.subway.path.dto.PathResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
@@ -9,8 +11,15 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 public class PathController {
 
+    private PathService pathService;
+
+    public PathController(PathService pathService) {
+        this.pathService = pathService;
+    }
+
     @GetMapping("/paths")
     public ResponseEntity getPaths(@ModelAttribute PathRequest pathRequest) {
-        return ResponseEntity.ok().build();
+        PathResponse pathResponse = pathService.findShortestPath(pathRequest);
+        return ResponseEntity.ok(pathResponse);
     }
 }

--- a/src/test/java/nextstep/subway/line/acceptance/LineSetionSteps.java
+++ b/src/test/java/nextstep/subway/line/acceptance/LineSetionSteps.java
@@ -16,7 +16,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 public class LineSetionSteps {
 
-    public static ExtractableResponse<Response> 지하철_노선에_지하철역_등록_요청(LineResponse line, StationResponse upStation, StationResponse downStation, int distance) {
+    public static ExtractableResponse<Response> 지하철_노선에_지하철역_등록_요청(
+            LineResponse line, StationResponse upStation, StationResponse downStation, int distance) {
         SectionRequest sectionRequest = new SectionRequest(upStation.getId(), downStation.getId(), distance);
 
         return RestAssured
@@ -36,7 +37,8 @@ public class LineSetionSteps {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.BAD_REQUEST.value());
     }
 
-    public static void 지하철_노선에_지하철역_순서_정렬됨(ExtractableResponse<Response> response, List<StationResponse> expectedStations) {
+    public static void 지하철_노선에_지하철역_순서_정렬됨(ExtractableResponse<Response> response,
+                                           List<StationResponse> expectedStations) {
         LineResponse line = response.as(LineResponse.class);
         List<Long> stationIds = line.getStations().stream()
                 .map(StationResponse::getId)
@@ -55,6 +57,11 @@ public class LineSetionSteps {
                 .when().delete("/lines/{lineId}/sections?stationId={stationId}", line.getId(), station.getId())
                 .then().log().all()
                 .extract();
+    }
+
+    public static ExtractableResponse<Response> 지하철_노선에_지하철역_등록되어_있음(
+            LineResponse line, StationResponse upStation, StationResponse downStation, int distance) {
+        return 지하철_노선에_지하철역_등록_요청(line, upStation, downStation, distance);
     }
 
     public static void 지하철_노선에_지하철역_제외됨(ExtractableResponse<Response> response) {

--- a/src/test/java/nextstep/subway/line/acceptance/LineSteps.java
+++ b/src/test/java/nextstep/subway/line/acceptance/LineSteps.java
@@ -5,6 +5,7 @@ import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
+import nextstep.subway.station.dto.StationResponse;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
@@ -14,6 +15,13 @@ import java.util.stream.Collectors;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class LineSteps {
+
+    public static LineResponse 지하철_노선_등록되어_있음(String lineName, String lineColor,
+                                              StationResponse upStation, StationResponse downStation, int distance) {
+        return 지하철_노선_생성_요청(
+                new LineRequest(lineName, lineColor, upStation.getId(), downStation.getId(), distance)
+        ).as(LineResponse.class);
+    }
 
     public static ExtractableResponse<Response> 지하철_노선_등록되어_있음(LineRequest params) {
         return 지하철_노선_생성_요청(params);

--- a/src/test/java/nextstep/subway/path/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/path/PathAcceptanceTest.java
@@ -1,9 +1,69 @@
 package nextstep.subway.path;
 
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
+import nextstep.subway.line.dto.LineRequest;
+import nextstep.subway.line.dto.LineResponse;
+import nextstep.subway.station.StationAcceptanceTest;
+import nextstep.subway.station.dto.StationResponse;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
 
+import static nextstep.subway.line.acceptance.LineSetionSteps.*;
+import static nextstep.subway.line.acceptance.LineSteps.*;
+import static nextstep.subway.path.PathSteps.*;
 
 @DisplayName("지하철 경로 조회")
 public class PathAcceptanceTest extends AcceptanceTest {
+
+    private LineResponse 신분당선;
+    private LineResponse 이호선;
+    private LineResponse 삼호선;
+    private StationResponse 강남역;
+    private StationResponse 양재역;
+    private StationResponse 교대역;
+    private StationResponse 남부터미널역;
+
+    /**
+     * 교대역    --- *2호선* ---   강남역
+     * |                        |
+     * *3호선*                   *신분당선*
+     * |                        |
+     * 남부터미널역  --- *3호선* ---   양재
+     */
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+
+        강남역 = StationAcceptanceTest.지하철역_등록되어_있음("강남역").as(StationResponse.class);
+        양재역 = StationAcceptanceTest.지하철역_등록되어_있음("양재역").as(StationResponse.class);
+        교대역 = StationAcceptanceTest.지하철역_등록되어_있음("교대역").as(StationResponse.class);
+        남부터미널역 = StationAcceptanceTest.지하철역_등록되어_있음("남부터미널역").as(StationResponse.class);
+
+        신분당선 = 지하철_노선_등록되어_있음(
+                makeParams("신분당선", "bg-red-600", 강남역, 양재역, 10)).as(LineResponse.class);
+        이호선 = 지하철_노선_등록되어_있음(
+                makeParams("이호선", "bg-red-600", 교대역, 강남역, 10)).as(LineResponse.class);
+        삼호선 = 지하철_노선_등록되어_있음(
+                makeParams("삼호선", "bg-red-600", 교대역, 양재역, 5)).as(LineResponse.class);
+
+        지하철_노선에_지하철역_등록되어_있음(삼호선, 교대역, 남부터미널역, 3);
+    }
+
+    private LineRequest makeParams(String lineName, String lineColor,
+                                   StationResponse source, StationResponse target, int distance) {
+        return new LineRequest(lineName, lineColor, source.getId(), target.getId(), distance);
+    }
+
+    @DisplayName("최단 경로를 조회한다.")
+    @Test
+    void findShortestPath() {
+        int expectedDistance = 10;
+        ExtractableResponse<Response> response = 지하철_노선_최단경로_조회_요청(교대역, 양재역);
+
+        지하철_노선_최단경로_조회됨(response);
+        //지하철_노선_최단경로_목록_정렬됨(response, expectedDistance);
+    }
 }

--- a/src/test/java/nextstep/subway/path/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/path/PathAcceptanceTest.java
@@ -3,18 +3,21 @@ package nextstep.subway.path;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
-import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.station.StationAcceptanceTest;
 import nextstep.subway.station.dto.StationResponse;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.test.context.ActiveProfiles;
+
+import java.util.Arrays;
 
 import static nextstep.subway.line.acceptance.LineSetionSteps.*;
 import static nextstep.subway.line.acceptance.LineSteps.*;
 import static nextstep.subway.path.PathSteps.*;
 
+@ActiveProfiles("test")
 @DisplayName("지하철 경로 조회")
 public class PathAcceptanceTest extends AcceptanceTest {
 
@@ -52,10 +55,11 @@ public class PathAcceptanceTest extends AcceptanceTest {
     @DisplayName("최단 경로를 조회한다.")
     @Test
     void findShortestPath() {
-        int expectedDistance = 10;
+        int expectedDistance = 5;
         ExtractableResponse<Response> response = 지하철_노선_최단경로_조회_요청(교대역, 양재역);
 
         지하철_노선_최단경로_조회됨(response);
-        //지하철_노선_최단경로_목록_정렬됨(response, expectedDistance);
+        지하철_노선_최단경로_목록_정렬됨(response, Arrays.asList(교대역, 남부터미널역, 양재역));
+        지하철_노선_최단경로_거리_응답됨(response, expectedDistance);
     }
 }

--- a/src/test/java/nextstep/subway/path/PathAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/path/PathAcceptanceTest.java
@@ -42,19 +42,11 @@ public class PathAcceptanceTest extends AcceptanceTest {
         교대역 = StationAcceptanceTest.지하철역_등록되어_있음("교대역").as(StationResponse.class);
         남부터미널역 = StationAcceptanceTest.지하철역_등록되어_있음("남부터미널역").as(StationResponse.class);
 
-        신분당선 = 지하철_노선_등록되어_있음(
-                makeParams("신분당선", "bg-red-600", 강남역, 양재역, 10)).as(LineResponse.class);
-        이호선 = 지하철_노선_등록되어_있음(
-                makeParams("이호선", "bg-red-600", 교대역, 강남역, 10)).as(LineResponse.class);
-        삼호선 = 지하철_노선_등록되어_있음(
-                makeParams("삼호선", "bg-red-600", 교대역, 양재역, 5)).as(LineResponse.class);
+        신분당선 = 지하철_노선_등록되어_있음("신분당선", "bg-red-600", 강남역, 양재역, 10);
+        이호선 = 지하철_노선_등록되어_있음("이호선", "bg-red-600", 교대역, 강남역, 10);
+        삼호선 = 지하철_노선_등록되어_있음("삼호선", "bg-red-600", 교대역, 양재역, 5);
 
         지하철_노선에_지하철역_등록되어_있음(삼호선, 교대역, 남부터미널역, 3);
-    }
-
-    private LineRequest makeParams(String lineName, String lineColor,
-                                   StationResponse source, StationResponse target, int distance) {
-        return new LineRequest(lineName, lineColor, source.getId(), target.getId(), distance);
     }
 
     @DisplayName("최단 경로를 조회한다.")

--- a/src/test/java/nextstep/subway/path/PathSteps.java
+++ b/src/test/java/nextstep/subway/path/PathSteps.java
@@ -1,0 +1,29 @@
+package nextstep.subway.path;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.station.dto.StationResponse;
+import org.springframework.http.HttpStatus;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class PathSteps {
+
+    public static ExtractableResponse<Response> 지하철_노선_최단경로_조회_요청(
+            StationResponse source, StationResponse target) {
+        return RestAssured.given().log().all()
+                .when()
+                .get("/paths?source={sourceId}&target={targetId}", source.getId(), target.getId())
+                .then().log().all()
+                .extract();
+    }
+
+    public static void 지하철_노선_최단경로_조회됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    public static void 지하철_노선_최단경로_목록_정렬됨(ExtractableResponse<Response> response, int expectedDistance) {
+
+    }
+}

--- a/src/test/java/nextstep/subway/path/PathSteps.java
+++ b/src/test/java/nextstep/subway/path/PathSteps.java
@@ -13,8 +13,10 @@ public class PathSteps {
     public static ExtractableResponse<Response> 지하철_노선_최단경로_조회_요청(
             StationResponse source, StationResponse target) {
         return RestAssured.given().log().all()
+                .queryParam("source", source.getId())
+                .queryParam("target", target.getId())
                 .when()
-                .get("/paths?source={sourceId}&target={targetId}", source.getId(), target.getId())
+                .get("/paths")
                 .then().log().all()
                 .extract();
     }

--- a/src/test/java/nextstep/subway/path/PathSteps.java
+++ b/src/test/java/nextstep/subway/path/PathSteps.java
@@ -3,8 +3,13 @@ package nextstep.subway.path;
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import nextstep.subway.path.dto.PathResponse;
+import nextstep.subway.station.domain.Station;
 import nextstep.subway.station.dto.StationResponse;
 import org.springframework.http.HttpStatus;
+
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -25,7 +30,22 @@ public class PathSteps {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
     }
 
-    public static void 지하철_노선_최단경로_목록_정렬됨(ExtractableResponse<Response> response, int expectedDistance) {
+    public static void 지하철_노선_최단경로_목록_정렬됨(ExtractableResponse<Response> response,
+                                          List<StationResponse> expected) {
+        PathResponse pathResponse = response.as(PathResponse.class);
+        List<Long> actualStationsId = pathResponse.getStations().stream()
+                .map(Station::getId)
+                .collect(Collectors.toList());
 
+        List<Long> expectedId = expected.stream()
+                .map(StationResponse::getId)
+                .collect(Collectors.toList());
+
+        assertThat(actualStationsId).containsExactlyElementsOf(expectedId);
+    }
+
+    public static void 지하철_노선_최단경로_거리_응답됨(ExtractableResponse<Response> response, int expectedDistance) {
+        PathResponse pathResponse = response.as(PathResponse.class);
+        assertThat(pathResponse.getDistance()).isEqualTo(expectedDistance);
     }
 }

--- a/src/test/java/nextstep/subway/path/application/PathServiceTest.java
+++ b/src/test/java/nextstep/subway/path/application/PathServiceTest.java
@@ -1,0 +1,54 @@
+package nextstep.subway.path.application;
+
+import nextstep.subway.line.domain.LineRepository;
+import nextstep.subway.path.dto.PathRequest;
+import nextstep.subway.path.dto.PathResponse;
+import nextstep.subway.station.domain.Station;
+import nextstep.subway.station.domain.StationRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Arrays;
+
+@ExtendWith(MockitoExtension.class)
+@ActiveProfiles("test")
+class PathServiceTest {
+
+    @Mock
+    private LineRepository lineRepository;
+
+    @Mock
+    private StationRepository stationRepository;
+
+    @InjectMocks
+    private PathService pathService;
+
+    private Station 강남역 = initStation("강남역", 1L);
+    private Station 양재역 = initStation("양재역", 2L);
+    private Station 교대역 = initStation("교대역", 3L);
+    private Station 남부터미널역 = initStation("남부터미널역", 4L);
+
+    @DisplayName("최단 경로 조회 테스트")
+    @Test
+    void findShortestPath() {
+        PathRequest pathRequest = new PathRequest(교대역.getId(), 양재역.getId());
+
+        PathResponse shortestPath = pathService.findShortestPath(pathRequest);
+
+        Assertions.assertThat(shortestPath.getStations())
+                .containsExactlyElementsOf(Arrays.asList(교대역, 남부터미널역, 양재역));
+    }
+
+    private Station initStation(String name, Long id) {
+        Station station = new Station(name);
+        ReflectionTestUtils.setField(station, "id", id);
+        return station;
+    }
+}

--- a/src/test/java/nextstep/subway/path/application/PathServiceTest.java
+++ b/src/test/java/nextstep/subway/path/application/PathServiceTest.java
@@ -1,11 +1,14 @@
 package nextstep.subway.path.application;
 
+import nextstep.subway.line.domain.Line;
 import nextstep.subway.line.domain.LineRepository;
+import nextstep.subway.line.domain.Section;
 import nextstep.subway.path.dto.PathRequest;
 import nextstep.subway.path.dto.PathResponse;
 import nextstep.subway.station.domain.Station;
 import nextstep.subway.station.domain.StationRepository;
 import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -16,6 +19,9 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.util.ReflectionTestUtils;
 
 import java.util.Arrays;
+
+import static java.util.Optional.*;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 @ActiveProfiles("test")
@@ -30,15 +36,29 @@ class PathServiceTest {
     @InjectMocks
     private PathService pathService;
 
-    private Station 강남역 = initStation("강남역", 1L);
-    private Station 양재역 = initStation("양재역", 2L);
-    private Station 교대역 = initStation("교대역", 3L);
-    private Station 남부터미널역 = initStation("남부터미널역", 4L);
+    private Station 강남역;
+    private Station 양재역;
+    private Station 교대역;
+    private Station 남부터미널역;
+    private Line 삼호선;
+
+    @BeforeEach
+    void setUp() {
+        강남역 = initStation("강남역", 1L);
+        양재역 = initStation("양재역", 2L);
+        교대역 = initStation("교대역", 3L);
+        남부터미널역 = initStation("남부터미널역", 4L);
+        삼호선 = initLine("3호선", "green", 교대역, 양재역, 5);
+        삼호선.addSection(new Section(삼호선, 교대역, 남부터미널역, 3));
+    }
 
     @DisplayName("최단 경로 조회 테스트")
     @Test
     void findShortestPath() {
         PathRequest pathRequest = new PathRequest(교대역.getId(), 양재역.getId());
+        when(lineRepository.findAll()).thenReturn(Arrays.asList(삼호선));
+        when(stationRepository.findById(교대역.getId())).thenReturn(ofNullable(교대역));
+        when(stationRepository.findById(양재역.getId())).thenReturn(ofNullable(양재역));
 
         PathResponse shortestPath = pathService.findShortestPath(pathRequest);
 
@@ -50,5 +70,12 @@ class PathServiceTest {
         Station station = new Station(name);
         ReflectionTestUtils.setField(station, "id", id);
         return station;
+    }
+
+    private Line initLine(String lineName, String color,
+                          Station upStation, Station downStation, int distance) {
+        Line line = new Line(lineName, color, upStation, downStation, distance);
+        ReflectionTestUtils.setField(line, "id", 1L);
+        return line;
     }
 }

--- a/src/test/java/nextstep/subway/path/domain/SubwayMapDataTest.java
+++ b/src/test/java/nextstep/subway/path/domain/SubwayMapDataTest.java
@@ -1,0 +1,73 @@
+package nextstep.subway.path.domain;
+
+import nextstep.subway.line.domain.Line;
+import nextstep.subway.line.domain.Section;
+import nextstep.subway.station.domain.Station;
+import org.jgrapht.graph.DefaultWeightedEdge;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SubwayMapDataTest {
+
+    /**
+     * 교대역   --- *2호선*(10)  ---     강남역
+     * |                                 |
+     * *3호선*(7)                     *신분당선* (4)
+     * |                                |
+     * 남부터미널역 --- *3호선*(10) --- 양재
+     *
+     * 춘천역 -----*춘천강원선*(20)------- 강원역
+     */
+
+    private Station 교대역;
+    private Station 남부터미널역;
+    private Station 양재역;
+    private Station 강남역;
+    private Station 춘천역;
+    private Station 강원역;
+    private Line 이호선;
+    private Line 삼호선;
+    private Line 신분당선;
+    private Line 춘천강원선;
+    private List<Line> 노선도;
+
+    @BeforeEach
+    void setUp() {
+        교대역 = initStation("교대역", 1L);
+        남부터미널역 = initStation("남부터미널역", 2L);
+        양재역 = initStation("양재역", 3L);
+        강남역 = initStation("강남역", 4L);
+        춘천역 = initStation("춘천역", 5L);
+        강원역 = initStation("강원역", 6L);
+
+        이호선 = new Line("2호선", "green", 교대역, 강남역, 10);
+        삼호선 = new Line("3호선", "orange", 교대역, 양재역, 17);
+        신분당선 = new Line("신분당선", "red", 강남역, 양재역, 4);
+        춘천강원선 = new Line("춘천강원선", "sky", 춘천역, 강원역, 20);
+
+        삼호선.addSection(new Section(삼호선, 교대역, 남부터미널역, 7));
+        노선도 = Arrays.asList(이호선, 삼호선, 신분당선, 춘천강원선);
+    }
+
+    @DisplayName("지하철 노선 데이터를 WeightedMultigraph 에 셋팅한다.")
+    @Test
+    void initData() {
+        SubwayMapData subwayMapData = new SubwayMapData(노선도, DefaultWeightedEdge.class);
+
+        assertThat(subwayMapData.initData().vertexSet()).isNotEmpty();
+        assertThat(subwayMapData.initData().edgeSet()).isNotEmpty();
+    }
+
+    private Station initStation(String name, Long id) {
+        Station station = new Station(name);
+        ReflectionTestUtils.setField(station, "id", id);
+        return station;
+    }
+}

--- a/src/test/java/nextstep/subway/path/domain/SubwayMapDataTest.java
+++ b/src/test/java/nextstep/subway/path/domain/SubwayMapDataTest.java
@@ -1,10 +1,7 @@
 package nextstep.subway.path.domain;
 
 import nextstep.subway.line.domain.Line;
-import nextstep.subway.line.domain.Section;
 import nextstep.subway.station.domain.Station;
-import org.assertj.core.api.Assertions;
-import org.jgrapht.graph.DefaultWeightedEdge;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -18,45 +15,18 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SubwayMapDataTest {
-
-    /**
-     * 교대역   --- *2호선*(10)  ---     강남역
-     * |                                 |
-     * *3호선*(7)                     *신분당선* (4)
-     * |                                |
-     * 남부터미널역 --- *3호선*(10) --- 양재
-     *
-     * 춘천역 -----*춘천강원선*(20)------- 강원역
-     */
-
     private Station 교대역;
-    private Station 남부터미널역;
-    private Station 양재역;
     private Station 강남역;
-    private Station 춘천역;
-    private Station 강원역;
     private Line 이호선;
-    private Line 삼호선;
-    private Line 신분당선;
-    private Line 춘천강원선;
     private List<Line> 노선도;
 
     @BeforeEach
     void setUp() {
         교대역 = initStation("교대역", 1L);
-        남부터미널역 = initStation("남부터미널역", 2L);
-        양재역 = initStation("양재역", 3L);
-        강남역 = initStation("강남역", 4L);
-        춘천역 = initStation("춘천역", 5L);
-        강원역 = initStation("강원역", 6L);
-
+        강남역 = initStation("강남역", 2L);
         이호선 = new Line("2호선", "green", 교대역, 강남역, 10);
-        삼호선 = new Line("3호선", "orange", 교대역, 양재역, 17);
-        신분당선 = new Line("신분당선", "red", 강남역, 양재역, 4);
-        춘천강원선 = new Line("춘천강원선", "sky", 춘천역, 강원역, 20);
 
-        삼호선.addSection(new Section(삼호선, 교대역, 남부터미널역, 7));
-        노선도 = Arrays.asList(이호선, 삼호선, 신분당선, 춘천강원선);
+        노선도 = Arrays.asList(이호선);
     }
 
     @DisplayName("지하철 노선 데이터를 WeightedMultigraph 에 셋팅한다.")

--- a/src/test/java/nextstep/subway/path/domain/SubwayMapDataTest.java
+++ b/src/test/java/nextstep/subway/path/domain/SubwayMapDataTest.java
@@ -3,16 +3,19 @@ package nextstep.subway.path.domain;
 import nextstep.subway.line.domain.Line;
 import nextstep.subway.line.domain.Section;
 import nextstep.subway.station.domain.Station;
+import org.assertj.core.api.Assertions;
 import org.jgrapht.graph.DefaultWeightedEdge;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 class SubwayMapDataTest {
 
@@ -63,6 +66,14 @@ class SubwayMapDataTest {
 
         assertThat(subwayMapData.initData().vertexSet()).isNotEmpty();
         assertThat(subwayMapData.initData().edgeSet()).isNotEmpty();
+    }
+
+    @DisplayName("노선도 값이 들어오지 않을 경우 예외가 발생한다")
+    @Test
+    void validateData() {
+        assertThatThrownBy(() -> new SubwayMapData(new ArrayList<>(), DefaultWeightedEdge.class))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("경로 조회에 필요한 노선도 값이 조회되지 않습니다.");
     }
 
     private Station initStation(String name, Long id) {

--- a/src/test/java/nextstep/subway/path/domain/SubwayMapDataTest.java
+++ b/src/test/java/nextstep/subway/path/domain/SubwayMapDataTest.java
@@ -62,7 +62,7 @@ class SubwayMapDataTest {
     @DisplayName("지하철 노선 데이터를 WeightedMultigraph 에 셋팅한다.")
     @Test
     void initData() {
-        SubwayMapData subwayMapData = new SubwayMapData(노선도, DefaultWeightedEdge.class);
+        SubwayMapData subwayMapData = new SubwayMapData(노선도, SectionEdge.class);
 
         assertThat(subwayMapData.initData().vertexSet()).isNotEmpty();
         assertThat(subwayMapData.initData().edgeSet()).isNotEmpty();
@@ -71,7 +71,7 @@ class SubwayMapDataTest {
     @DisplayName("노선도 값이 들어오지 않을 경우 예외가 발생한다")
     @Test
     void validateData() {
-        assertThatThrownBy(() -> new SubwayMapData(new ArrayList<>(), DefaultWeightedEdge.class))
+        assertThatThrownBy(() -> new SubwayMapData(new ArrayList<>(), SectionEdge.class))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("경로 조회에 필요한 노선도 값이 조회되지 않습니다.");
     }

--- a/src/test/java/nextstep/subway/path/domain/SubwayNavigationTest.java
+++ b/src/test/java/nextstep/subway/path/domain/SubwayNavigationTest.java
@@ -81,6 +81,18 @@ class SubwayNavigationTest {
                 .hasMessage("같은 역으로 경로를 조회할 수 없습니다.");
     }
 
+    @DisplayName("경로 내의 지하철역 조회시 예외발생 - case 2 : 출발역과 도착역이 연결되어 있지 않은 경우")
+    @Test
+    void getPaths_exception_2() {
+        SubwayMapData subwayMapData = new SubwayMapData(노선도, SectionEdge.class);
+
+        SubwayNavigation subwayNavigation = new SubwayNavigation(subwayMapData.initData());
+
+        assertThatThrownBy(() -> subwayNavigation.getPaths(강남역, 강원역))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("노선이 연결되어 있지 않습니다.");
+    }
+
     @Test
     void getDistance() {
 

--- a/src/test/java/nextstep/subway/path/domain/SubwayNavigationTest.java
+++ b/src/test/java/nextstep/subway/path/domain/SubwayNavigationTest.java
@@ -91,7 +91,7 @@ class SubwayNavigationTest {
                 .hasMessage("노선이 연결되어 있지 않습니다.");
     }
 
-    @DisplayName("경로 내의 지하철역 조회시 예외발생 - case 3 : 존재하지 않는 역을 조회할 경우")
+    @DisplayName("경로 내의 지하철역 조회시 예외발생 - case 3 : 경로상에 존재하지 않는 역을 조회할 경우")
     @Test
     void getPaths_exception_3() {
         SubwayMapData subwayMapData = new SubwayMapData(노선도, SectionEdge.class);
@@ -103,6 +103,20 @@ class SubwayNavigationTest {
         assertThatThrownBy(() -> subwayNavigation.getPaths(처음보는역, 못보던역))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("graph must contain the source vertex");
+    }
+
+    @DisplayName("경로 내의 지하철역 조회시 예외발생 - case 4 : 없는(null) 역을 조회할 경우")
+    @Test
+    void getPaths_exception_4() {
+        SubwayMapData subwayMapData = new SubwayMapData(노선도, SectionEdge.class);
+        Station 없는역1= null;
+        Station 없는역2 = null;
+
+        SubwayNavigation subwayNavigation = new SubwayNavigation(subwayMapData.initData());
+
+        assertThatThrownBy(() -> subwayNavigation.getPaths(없는역1, 없는역2))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("기존에 등록되지 않은 역입니다.");
     }
 
     @Test

--- a/src/test/java/nextstep/subway/path/domain/SubwayNavigationTest.java
+++ b/src/test/java/nextstep/subway/path/domain/SubwayNavigationTest.java
@@ -12,6 +12,9 @@ import org.springframework.test.util.ReflectionTestUtils;
 import java.util.Arrays;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
 class SubwayNavigationTest {
 
     /**
@@ -20,7 +23,7 @@ class SubwayNavigationTest {
      * *3호선*(7)                     *신분당선* (4)
      * |                                |
      * 남부터미널역 --- *3호선*(10) --- 양재
-     *
+     * <p>
      * 춘천역 -----*춘천강원선*(20)------- 강원역
      */
 
@@ -63,12 +66,24 @@ class SubwayNavigationTest {
         SubwayNavigation subwayNavigation = new SubwayNavigation(subwayMapData.initData());
 
         List<Station> stations = subwayNavigation.getPaths(강남역, 남부터미널역);
-        Assertions.assertThat(stations).containsExactly(강남역, 양재역, 남부터미널역);
+        assertThat(stations).containsExactly(강남역, 양재역, 남부터미널역);
+    }
+
+    @DisplayName("경로 내의 지하철역 조회시 예외발생 - case 1 : 출발역과 도착역이 같은 경우")
+    @Test
+    void getPaths_exception_1() {
+        SubwayMapData subwayMapData = new SubwayMapData(노선도, SectionEdge.class);
+
+        SubwayNavigation subwayNavigation = new SubwayNavigation(subwayMapData.initData());
+
+        assertThatThrownBy(() -> subwayNavigation.getPaths(강남역, 강남역))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("같은 역으로 경로를 조회할 수 없습니다.");
     }
 
     @Test
     void getDistance() {
-        
+
     }
 
     private Station initStation(String name, Long id) {

--- a/src/test/java/nextstep/subway/path/domain/SubwayNavigationTest.java
+++ b/src/test/java/nextstep/subway/path/domain/SubwayNavigationTest.java
@@ -119,6 +119,14 @@ class SubwayNavigationTest {
                 .hasMessage("기존에 등록되지 않은 역입니다.");
     }
 
+    @DisplayName("경로 내의 지하철역 조회시 예외발생 - case 5 : 조회를 위한 참조 graph 값이 없는 경우")
+    @Test
+    void getPaths_exception_5() {
+        assertThatThrownBy(() -> new SubwayNavigation(null))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("경로 조회를 위한 객체 그래프 값이 없습니다.");
+    }
+
     @Test
     void getDistance() {
 

--- a/src/test/java/nextstep/subway/path/domain/SubwayNavigationTest.java
+++ b/src/test/java/nextstep/subway/path/domain/SubwayNavigationTest.java
@@ -3,7 +3,6 @@ package nextstep.subway.path.domain;
 import nextstep.subway.line.domain.Line;
 import nextstep.subway.line.domain.Section;
 import nextstep.subway.station.domain.Station;
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -57,7 +56,6 @@ class SubwayNavigationTest {
         노선도 = Arrays.asList(이호선, 삼호선, 신분당선, 춘천강원선);
     }
 
-
     @DisplayName("경로 내의 지하철역들을 조회한다.")
     @Test
     void getPaths() {
@@ -91,6 +89,20 @@ class SubwayNavigationTest {
         assertThatThrownBy(() -> subwayNavigation.getPaths(강남역, 강원역))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessage("노선이 연결되어 있지 않습니다.");
+    }
+
+    @DisplayName("경로 내의 지하철역 조회시 예외발생 - case 3 : 존재하지 않는 역을 조회할 경우")
+    @Test
+    void getPaths_exception_3() {
+        SubwayMapData subwayMapData = new SubwayMapData(노선도, SectionEdge.class);
+        Station 처음보는역 = new Station("처음보는역");
+        Station 못보던역 = new Station("못보던역");
+
+        SubwayNavigation subwayNavigation = new SubwayNavigation(subwayMapData.initData());
+
+        assertThatThrownBy(() -> subwayNavigation.getPaths(처음보는역, 못보던역))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("graph must contain the source vertex");
     }
 
     @Test

--- a/src/test/java/nextstep/subway/path/domain/SubwayNavigationTest.java
+++ b/src/test/java/nextstep/subway/path/domain/SubwayNavigationTest.java
@@ -1,0 +1,72 @@
+package nextstep.subway.path.domain;
+
+import nextstep.subway.line.domain.Line;
+import nextstep.subway.line.domain.Section;
+import nextstep.subway.station.domain.Station;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Arrays;
+import java.util.List;
+
+class SubwayNavigationTest {
+
+    /**
+     * 교대역   --- *2호선*(10)  ---     강남역
+     * |                                 |
+     * *3호선*(7)                     *신분당선* (4)
+     * |                                |
+     * 남부터미널역 --- *3호선*(10) --- 양재
+     *
+     * 춘천역 -----*춘천강원선*(20)------- 강원역
+     */
+
+    private Station 교대역;
+    private Station 남부터미널역;
+    private Station 양재역;
+    private Station 강남역;
+    private Station 춘천역;
+    private Station 강원역;
+    private Line 이호선;
+    private Line 삼호선;
+    private Line 신분당선;
+    private Line 춘천강원선;
+    private List<Line> 노선도;
+
+    @BeforeEach
+    void setUp() {
+        교대역 = initStation("교대역", 1L);
+        남부터미널역 = initStation("남부터미널역", 2L);
+        양재역 = initStation("양재역", 3L);
+        강남역 = initStation("강남역", 4L);
+        춘천역 = initStation("춘천역", 5L);
+        강원역 = initStation("강원역", 6L);
+
+        이호선 = new Line("2호선", "green", 교대역, 강남역, 10);
+        삼호선 = new Line("3호선", "orange", 교대역, 양재역, 17);
+        신분당선 = new Line("신분당선", "red", 강남역, 양재역, 4);
+        춘천강원선 = new Line("춘천강원선", "sky", 춘천역, 강원역, 20);
+
+        삼호선.addSection(new Section(삼호선, 교대역, 남부터미널역, 7));
+        노선도 = Arrays.asList(이호선, 삼호선, 신분당선, 춘천강원선);
+    }
+
+
+    @DisplayName("경로 내의 지하철역들을 조회한다.")
+    @Test
+    void getPaths() {
+
+    }
+
+    @Test
+    void getDistance() {
+    }
+
+    private Station initStation(String name, Long id) {
+        Station station = new Station(name);
+        ReflectionTestUtils.setField(station, "id", id);
+        return station;
+    }
+}

--- a/src/test/java/nextstep/subway/path/domain/SubwayNavigationTest.java
+++ b/src/test/java/nextstep/subway/path/domain/SubwayNavigationTest.java
@@ -3,6 +3,7 @@ package nextstep.subway.path.domain;
 import nextstep.subway.line.domain.Line;
 import nextstep.subway.line.domain.Section;
 import nextstep.subway.station.domain.Station;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -57,11 +58,17 @@ class SubwayNavigationTest {
     @DisplayName("경로 내의 지하철역들을 조회한다.")
     @Test
     void getPaths() {
+        SubwayMapData subwayMapData = new SubwayMapData(노선도, SectionEdge.class);
 
+        SubwayNavigation subwayNavigation = new SubwayNavigation(subwayMapData.initData());
+
+        List<Station> stations = subwayNavigation.getPaths(강남역, 남부터미널역);
+        Assertions.assertThat(stations).containsExactly(강남역, 양재역, 남부터미널역);
     }
 
     @Test
     void getDistance() {
+        
     }
 
     private Station initStation(String name, Long id) {

--- a/src/test/java/nextstep/subway/path/domain/SubwayNavigationTest.java
+++ b/src/test/java/nextstep/subway/path/domain/SubwayNavigationTest.java
@@ -22,7 +22,7 @@ class SubwayNavigationTest {
      * *3호선*(7)                     *신분당선* (4)
      * |                                |
      * 남부터미널역 --- *3호선*(10) --- 양재
-     * <p>
+     *
      * 춘천역 -----*춘천강원선*(20)------- 강원역
      */
 
@@ -127,9 +127,16 @@ class SubwayNavigationTest {
                 .hasMessage("경로 조회를 위한 객체 그래프 값이 없습니다.");
     }
 
+    @DisplayName("최단경로를 조회하여 거리를 구한다.")
     @Test
     void getDistance() {
+        SubwayMapData subwayMapData = new SubwayMapData(노선도, SectionEdge.class);
 
+        SubwayNavigation subwayNavigation = new SubwayNavigation(subwayMapData.initData());
+
+        int distance = subwayNavigation.getDistance(교대역, 양재역);
+        int expectedDistance = 14;
+        assertThat(distance).isEqualTo(expectedDistance);
     }
 
     private Station initStation(String name, Long id) {


### PR DESCRIPTION
안녕하세요 리뷰어님-!
늦었습니다 ㅠ

처음 다익스트라 경로 찾기 구현은 어렵지 않았는데,
의존성에 대한 생각과 설계에 고민을 하다보니
시간이 오래 걸렸습니다.

최대한 외부 라이브러리의 의존성을 줄여보려 했는데,
잘 되었는지 모르겠네요 @.@;;

가감없는 리뷰 부탁드립니다-!

p.s **질문이 있습니다..**
 PathService 의
```java
List<Line> lines = lineRepository.findAll();
Station source = findStation(pathRequest.getSource());
Station target = findStation(pathRequest.getTarget()); 
```
이 부분을 lines 조회한 내용으로 source 역과 target 역을 
조회하는 로직을 짜봤었었는데요..
이 때에 Stream 등으로 구현하게 되면 getter가 필요하게 되고
억지로 getter를 없애려다 보면(객체지향적으로..), 각 도메인 객체에 메소드들이 
상당히 많이 생기게 되더라구요
로직도 복잡해지구요..
배보다 배꼽이 커지는 거 같아서 일단은 db에서 조회해오는 것으로 놔두었는데요..
(사실 DB 커넥션 하는 게 아무래도 실제 운영시에는 화면이 뜰 때 딜레이(?) 가 더 많이 생길거 같아서
한번만 조회해온 내용으로 다 처리하려던 거거든요..)
리뷰어님께서는 어떤 방법을 선호하시는지 의견을 듣고 싶습니다.