### PR TITLE
[Step3] 인증을 통한 기능 구현

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
     - [x] 내 정보 조회 (GET /members/me)
         - [x] 토큰을 확인해 로그인 정보를 응답
         - [x] @AuthenticationPrincipal과 AuthenticationPrincipalArgumentResolver을 활용
-    - [ ] 내 정보 변경 기능 (PUT /members/me)
+    - [x] 내 정보 변경 기능 (PUT /members/me)
     - [ ] 내 정보 삭제 기능 (DELETE /members/me)
 - [ ] 즐겨 찾기 기능 구현
     - [ ] 시나리오 기반으로 인수테스트 작성 및 통과 시키기

--- a/README.md
+++ b/README.md
@@ -1,3 +1,19 @@
+### Step3 요구사항
+
+- [ ] 토큰 발급 기능(로그인) (POST /login/token)
+    - [ ] 이메일, 패스워드를 받아 인증 후 access token 응답
+- [ ] 내 정보 기능
+    - [ ] 내 정보 조회 (GET /members/me)
+        - [ ] 토큰을 확인해 로그인 정보를 응답
+        - [ ] @AuthenticationPrincipal과 AuthenticationPrincipalArgumentResolver을 활용
+    - [ ] 내 정보 변경 기능 (PUT /members/me)
+    - [ ] 내 정보 삭제 기능 (DELETE /members/me)
+- [ ] 즐겨 찾기 기능 구현
+    - [ ] 시나리오 기반으로 인수테스트 작성 및 통과 시키기
+    - [ ] 즐겨찾기 생성 (POST /favorites)
+    - [ ] 즐겨찾기 목록 불러오기 (GET /favorites)
+    - [ ] 즐겨찾기 삭제 (DELETE /favorites/:id)
+
 ### Step2 요구사항
 
 - [x] 최단 경로 조회 인수 테스트 만들기

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@
     - [x] 내 정보 삭제 기능 (DELETE /members/me)
 - [ ] 즐겨 찾기 기능 구현
     - [ ] 시나리오 기반으로 인수테스트 작성 및 통과 시키기
+    - [ ] Favorite 도메인 엔티티 생성
+        - [ ] 멤버, Source Station, Target Station와 관계매핑
     - [ ] 즐겨찾기 생성 (POST /favorites)
     - [ ] 즐겨찾기 목록 불러오기 (GET /favorites)
     - [ ] 즐겨찾기 삭제 (DELETE /favorites/:id)

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 - [x] 토큰 발급 기능(로그인) (POST /login/token)
     - [x] 이메일, 패스워드를 받아 인증 후 access token 응답
 - [ ] 내 정보 기능
-    - [ ] 내 정보 조회 (GET /members/me)
-        - [ ] 토큰을 확인해 로그인 정보를 응답
-        - [ ] @AuthenticationPrincipal과 AuthenticationPrincipalArgumentResolver을 활용
+    - [x] 내 정보 조회 (GET /members/me)
+        - [x] 토큰을 확인해 로그인 정보를 응답
+        - [x] @AuthenticationPrincipal과 AuthenticationPrincipalArgumentResolver을 활용
     - [ ] 내 정보 변경 기능 (PUT /members/me)
     - [ ] 내 정보 삭제 기능 (DELETE /members/me)
 - [ ] 즐겨 찾기 기능 구현

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@
     - [x] 내 정보 삭제 기능 (DELETE /members/me)
 - [ ] 즐겨 찾기 기능 구현
     - [ ] 시나리오 기반으로 인수테스트 작성 및 통과 시키기
-    - [ ] Favorite 도메인 엔티티 생성
-        - [ ] 멤버, Source Station, Target Station와 관계매핑
+    - [x] Favorite 도메인 엔티티 생성
+        - [x] 멤버, Source Station, Target Station와 관계매핑
     - [ ] 즐겨찾기 생성 (POST /favorites)
     - [ ] 즐겨찾기 목록 불러오기 (GET /favorites)
     - [ ] 즐겨찾기 삭제 (DELETE /favorites/:id)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ### Step3 요구사항
 
-- [ ] 토큰 발급 기능(로그인) (POST /login/token)
-    - [ ] 이메일, 패스워드를 받아 인증 후 access token 응답
+- [x] 토큰 발급 기능(로그인) (POST /login/token)
+    - [x] 이메일, 패스워드를 받아 인증 후 access token 응답
 - [ ] 내 정보 기능
     - [ ] 내 정보 조회 (GET /members/me)
         - [ ] 토큰을 확인해 로그인 정보를 응답

--- a/README.md
+++ b/README.md
@@ -2,12 +2,12 @@
 
 - [x] 토큰 발급 기능(로그인) (POST /login/token)
     - [x] 이메일, 패스워드를 받아 인증 후 access token 응답
-- [ ] 내 정보 기능
+- [x] 내 정보 기능
     - [x] 내 정보 조회 (GET /members/me)
         - [x] 토큰을 확인해 로그인 정보를 응답
         - [x] @AuthenticationPrincipal과 AuthenticationPrincipalArgumentResolver을 활용
     - [x] 내 정보 변경 기능 (PUT /members/me)
-    - [ ] 내 정보 삭제 기능 (DELETE /members/me)
+    - [x] 내 정보 삭제 기능 (DELETE /members/me)
 - [ ] 즐겨 찾기 기능 구현
     - [ ] 시나리오 기반으로 인수테스트 작성 및 통과 시키기
     - [ ] 즐겨찾기 생성 (POST /favorites)

--- a/README.md
+++ b/README.md
@@ -8,13 +8,13 @@
         - [x] @AuthenticationPrincipal과 AuthenticationPrincipalArgumentResolver을 활용
     - [x] 내 정보 변경 기능 (PUT /members/me)
     - [x] 내 정보 삭제 기능 (DELETE /members/me)
-- [ ] 즐겨 찾기 기능 구현
-    - [ ] 시나리오 기반으로 인수테스트 작성 및 통과 시키기
+- [x] 즐겨 찾기 기능 구현
+    - [x] 시나리오 기반으로 인수테스트 작성 및 통과 시키기
     - [x] Favorite 도메인 엔티티 생성
         - [x] 멤버, Source Station, Target Station와 관계매핑
-    - [ ] 즐겨찾기 생성 (POST /favorites)
-    - [ ] 즐겨찾기 목록 불러오기 (GET /favorites)
-    - [ ] 즐겨찾기 삭제 (DELETE /favorites/:id)
+    - [x] 즐겨찾기 생성 (POST /favorites)
+    - [x] 즐겨찾기 목록 불러오기 (GET /favorites)
+    - [x] 즐겨찾기 삭제 (DELETE /favorites/:id)
 
 ### Step2 요구사항
 

--- a/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
+++ b/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
@@ -1,0 +1,43 @@
+package nextstep.subway.favorite.application;
+
+import nextstep.subway.auth.domain.LoginMember;
+import nextstep.subway.favorite.domain.Favorite;
+import nextstep.subway.favorite.domain.FavoriteRepository;
+import nextstep.subway.favorite.dto.FavoriteRequest;
+import nextstep.subway.favorite.dto.FavoriteResponse;
+import nextstep.subway.member.application.MemberService;
+import nextstep.subway.member.domain.Member;
+import nextstep.subway.station.application.StationService;
+import nextstep.subway.station.domain.Station;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional
+public class FavoriteService {
+    private FavoriteRepository favoriteRepository;
+    private StationService stationService;
+    private MemberService memberService;
+
+    public FavoriteService(FavoriteRepository favoriteRepository, StationService stationService,
+                           MemberService memberService) {
+        this.favoriteRepository = favoriteRepository;
+        this.stationService = stationService;
+        this.memberService = memberService;
+    }
+
+    public FavoriteResponse saveFavorite(LoginMember loginMember, FavoriteRequest favoriteRequest) {
+        Member member = memberService.findMemberById(loginMember.getId());
+        Station sourceStation = stationService.findById(favoriteRequest.getSource());
+        Station targetStation = stationService.findById(favoriteRequest.getTarget());
+
+        Favorite newFavorite = favoriteRepository.save(new Favorite.Builder()
+                .member(member)
+                .source(sourceStation)
+                .target(targetStation)
+                .build()
+        );
+
+        return FavoriteResponse.from(newFavorite);
+    }
+}

--- a/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
+++ b/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
@@ -1,5 +1,7 @@
 package nextstep.subway.favorite.application;
 
+import java.util.List;
+import java.util.stream.Collectors;
 import nextstep.subway.auth.domain.LoginMember;
 import nextstep.subway.favorite.domain.Favorite;
 import nextstep.subway.favorite.domain.FavoriteRepository;
@@ -39,5 +41,12 @@ public class FavoriteService {
         );
 
         return FavoriteResponse.from(newFavorite);
+    }
+
+    public List<FavoriteResponse> findFavoriteResponses(LoginMember loginMember) {
+        List<Favorite> favorites = favoriteRepository.findByMemberId(loginMember.getId());
+        return favorites.stream()
+                .map(FavoriteResponse::from)
+                .collect(Collectors.toList());
     }
 }

--- a/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
+++ b/src/main/java/nextstep/subway/favorite/application/FavoriteService.java
@@ -49,4 +49,8 @@ public class FavoriteService {
                 .map(FavoriteResponse::from)
                 .collect(Collectors.toList());
     }
+
+    public void deleteFavoriteById(Long id) {
+        favoriteRepository.deleteById(id);
+    }
 }

--- a/src/main/java/nextstep/subway/favorite/domain/Favorite.java
+++ b/src/main/java/nextstep/subway/favorite/domain/Favorite.java
@@ -1,0 +1,68 @@
+package nextstep.subway.favorite.domain;
+
+import javax.persistence.CascadeType;
+import javax.persistence.Entity;
+import javax.persistence.FetchType;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+import nextstep.subway.member.domain.Member;
+import nextstep.subway.station.domain.Station;
+
+@Entity
+public class Favorite {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "source_id")
+    private Station source;
+
+    @ManyToOne(fetch = FetchType.LAZY, cascade = CascadeType.PERSIST)
+    @JoinColumn(name = "target_id")
+    private Station target;
+
+    public static class Builder {
+        private Member member;
+        private Station source;
+        private Station target;
+
+
+        public Builder() {
+        }
+
+        public Builder member(Member member) {
+            this.member = member;
+            return this;
+        }
+
+        public Builder source(Station station) {
+            this.source = station;
+            return this;
+        }
+
+        public Builder target(Station station) {
+            this.target = station;
+            return this;
+        }
+
+        public Favorite build() {
+            return new Favorite(member, target, source);
+        }
+    }
+
+    protected Favorite() {
+    }
+
+    public Favorite(Member member, Station source, Station target) {
+        this.member = member;
+        this.source = source;
+        this.target = target;
+    }
+}

--- a/src/main/java/nextstep/subway/favorite/domain/Favorite.java
+++ b/src/main/java/nextstep/subway/favorite/domain/Favorite.java
@@ -65,4 +65,21 @@ public class Favorite {
         this.source = source;
         this.target = target;
     }
+
+    public Long getId() {
+        return id;
+    }
+
+    public Member getMember() {
+        return member;
+    }
+
+    public Station getSource() {
+        return source;
+    }
+
+    public Station getTarget() {
+        return target;
+    }
+
 }

--- a/src/main/java/nextstep/subway/favorite/domain/FavoriteRepository.java
+++ b/src/main/java/nextstep/subway/favorite/domain/FavoriteRepository.java
@@ -1,0 +1,6 @@
+package nextstep.subway.favorite.domain;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+}

--- a/src/main/java/nextstep/subway/favorite/domain/FavoriteRepository.java
+++ b/src/main/java/nextstep/subway/favorite/domain/FavoriteRepository.java
@@ -1,6 +1,8 @@
 package nextstep.subway.favorite.domain;
 
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface FavoriteRepository extends JpaRepository<Favorite, Long> {
+    List<Favorite> findByMemberId(Long id);
 }

--- a/src/main/java/nextstep/subway/favorite/dto/FavoriteRequest.java
+++ b/src/main/java/nextstep/subway/favorite/dto/FavoriteRequest.java
@@ -1,0 +1,27 @@
+package nextstep.subway.favorite.dto;
+
+public class FavoriteRequest {
+    private Long source;
+    private Long target;
+
+    public FavoriteRequest(Long source, Long target) {
+        this.source = source;
+        this.target = target;
+    }
+
+    public Long getSource() {
+        return source;
+    }
+
+    public void setSource(Long source) {
+        this.source = source;
+    }
+
+    public Long getTarget() {
+        return target;
+    }
+
+    public void setTarget(Long target) {
+        this.target = target;
+    }
+}

--- a/src/main/java/nextstep/subway/favorite/dto/FavoriteResponse.java
+++ b/src/main/java/nextstep/subway/favorite/dto/FavoriteResponse.java
@@ -1,0 +1,42 @@
+package nextstep.subway.favorite.dto;
+
+import nextstep.subway.favorite.domain.Favorite;
+import nextstep.subway.station.domain.Station;
+import nextstep.subway.station.dto.StationResponse;
+
+public class FavoriteResponse {
+    private Long id;
+
+    private StationResponse source;
+    private StationResponse target;
+
+    public FavoriteResponse() {
+    }
+
+    public FavoriteResponse(Long id, StationResponse source, StationResponse target) {
+
+        this.id = id;
+        this.source = source;
+        this.target = target;
+    }
+
+    public static FavoriteResponse from(Favorite favorite) {
+        return new FavoriteResponse(
+                favorite.getId(),
+                StationResponse.of(favorite.getSource()),
+                StationResponse.of(favorite.getTarget())
+        );
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public StationResponse getSource() {
+        return source;
+    }
+
+    public StationResponse getTarget() {
+        return target;
+    }
+}

--- a/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
+++ b/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
@@ -1,0 +1,30 @@
+package nextstep.subway.favorite.ui;
+
+import java.net.URI;
+import nextstep.subway.auth.domain.AuthenticationPrincipal;
+import nextstep.subway.auth.domain.LoginMember;
+import nextstep.subway.favorite.application.FavoriteService;
+import nextstep.subway.favorite.dto.FavoriteRequest;
+import nextstep.subway.favorite.dto.FavoriteResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/favorites")
+public class FavoriteController {
+    private final FavoriteService favoriteService;
+
+    public FavoriteController(final FavoriteService favoriteService) {
+        this.favoriteService = favoriteService;
+    }
+
+    @PostMapping
+    public ResponseEntity createFavorite(@AuthenticationPrincipal LoginMember loginMember,
+                                         @RequestBody FavoriteRequest request) {
+        FavoriteResponse favorite = favoriteService.saveFavorite(loginMember, request);
+        return ResponseEntity.created(URI.create("/favorites/" + favorite.getId())).body(favorite);
+    }
+}

--- a/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
+++ b/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
@@ -8,7 +8,9 @@ import nextstep.subway.favorite.application.FavoriteService;
 import nextstep.subway.favorite.dto.FavoriteRequest;
 import nextstep.subway.favorite.dto.FavoriteResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -33,5 +35,11 @@ public class FavoriteController {
     @GetMapping
     public ResponseEntity<List<FavoriteResponse>> findFavorites(@AuthenticationPrincipal LoginMember loginMember) {
         return ResponseEntity.ok(favoriteService.findFavoriteResponses(loginMember));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity deleteFavorite(@PathVariable Long id) {
+        favoriteService.deleteFavoriteById(id);
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
+++ b/src/main/java/nextstep/subway/favorite/ui/FavoriteController.java
@@ -1,12 +1,14 @@
 package nextstep.subway.favorite.ui;
 
 import java.net.URI;
+import java.util.List;
 import nextstep.subway.auth.domain.AuthenticationPrincipal;
 import nextstep.subway.auth.domain.LoginMember;
 import nextstep.subway.favorite.application.FavoriteService;
 import nextstep.subway.favorite.dto.FavoriteRequest;
 import nextstep.subway.favorite.dto.FavoriteResponse;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -26,5 +28,10 @@ public class FavoriteController {
                                          @RequestBody FavoriteRequest request) {
         FavoriteResponse favorite = favoriteService.saveFavorite(loginMember, request);
         return ResponseEntity.created(URI.create("/favorites/" + favorite.getId())).body(favorite);
+    }
+
+    @GetMapping
+    public ResponseEntity<List<FavoriteResponse>> findFavorites(@AuthenticationPrincipal LoginMember loginMember) {
+        return ResponseEntity.ok(favoriteService.findFavoriteResponses(loginMember));
     }
 }

--- a/src/main/java/nextstep/subway/member/application/MemberService.java
+++ b/src/main/java/nextstep/subway/member/application/MemberService.java
@@ -21,8 +21,7 @@ public class MemberService {
     }
 
     public MemberResponse findMember(Long id) {
-        Member member = memberRepository.findById(id).orElseThrow(RuntimeException::new);
-        return MemberResponse.of(member);
+        return MemberResponse.of(findMemberById(id));
     }
 
     public void updateMember(Long id, MemberRequest param) {
@@ -32,5 +31,9 @@ public class MemberService {
 
     public void deleteMember(Long id) {
         memberRepository.deleteById(id);
+    }
+
+    public Member findMemberById(Long id) {
+        return memberRepository.findById(id).orElseThrow(RuntimeException::new);
     }
 }

--- a/src/main/java/nextstep/subway/member/ui/MemberController.java
+++ b/src/main/java/nextstep/subway/member/ui/MemberController.java
@@ -57,7 +57,7 @@ public class MemberController {
     }
 
     @DeleteMapping("/members/me")
-    public ResponseEntity<MemberResponse> deleteMemberOfMine(LoginMember loginMember) {
+    public ResponseEntity<MemberResponse> deleteMemberOfMine(@AuthenticationPrincipal LoginMember loginMember) {
         memberService.deleteMember(loginMember.getId());
         return ResponseEntity.noContent().build();
     }

--- a/src/main/java/nextstep/subway/member/ui/MemberController.java
+++ b/src/main/java/nextstep/subway/member/ui/MemberController.java
@@ -50,7 +50,7 @@ public class MemberController {
     }
 
     @PutMapping("/members/me")
-    public ResponseEntity<MemberResponse> updateMemberOfMine(LoginMember loginMember,
+    public ResponseEntity<MemberResponse> updateMemberOfMine(@AuthenticationPrincipal LoginMember loginMember,
                                                              @RequestBody MemberRequest param) {
         memberService.updateMember(loginMember.getId(), param);
         return ResponseEntity.ok().build();

--- a/src/main/java/nextstep/subway/member/ui/MemberController.java
+++ b/src/main/java/nextstep/subway/member/ui/MemberController.java
@@ -44,13 +44,14 @@ public class MemberController {
     }
 
     @GetMapping("/members/me")
-    public ResponseEntity<MemberResponse> findMemberOfMine(LoginMember loginMember) {
+    public ResponseEntity<MemberResponse> findMemberOfMine(@AuthenticationPrincipal LoginMember loginMember) {
         MemberResponse member = memberService.findMember(loginMember.getId());
         return ResponseEntity.ok().body(member);
     }
 
     @PutMapping("/members/me")
-    public ResponseEntity<MemberResponse> updateMemberOfMine(LoginMember loginMember, @RequestBody MemberRequest param) {
+    public ResponseEntity<MemberResponse> updateMemberOfMine(LoginMember loginMember,
+                                                             @RequestBody MemberRequest param) {
         memberService.updateMember(loginMember.getId(), param);
         return ResponseEntity.ok().build();
     }

--- a/src/test/java/nextstep/subway/auth/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/auth/acceptance/AuthAcceptanceTest.java
@@ -62,7 +62,7 @@ public class AuthAcceptanceTest extends AcceptanceTest {
         유효하지_않은_토큰(response);
     }
 
-    private static ExtractableResponse<Response> 토큰_요청(TokenRequest params) {
+    public static ExtractableResponse<Response> 토큰_요청(TokenRequest params) {
         return RestAssured
                 .given().log().all()
                 .contentType(MediaType.APPLICATION_JSON_VALUE)

--- a/src/test/java/nextstep/subway/auth/acceptance/AuthAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/auth/acceptance/AuthAcceptanceTest.java
@@ -1,24 +1,86 @@
 package nextstep.subway.auth.acceptance;
 
+import static nextstep.subway.member.MemberAcceptanceTest.나의_정보_조회_요청;
+import static nextstep.subway.member.MemberAcceptanceTest.회원_생성을_요청;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
+import nextstep.subway.auth.dto.TokenRequest;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
 
 public class AuthAcceptanceTest extends AcceptanceTest {
 
+    private static final String email = "email@email.com";
+    private static final String password = "password";
+    private static final int age = 20;
+    private TokenRequest tokenRequest;
+
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+
+        //given
+        회원_생성을_요청(email, password, age);
+
+        tokenRequest = new TokenRequest(email, password);
+    }
+
     @DisplayName("Bearer Auth")
     @Test
-    void myInfoWithBearerAuth() {
+    void loginWithBearerAuth() {
+        // when
+        ExtractableResponse<Response> response = 토큰_요청(tokenRequest);
+
+        // then
+        토큰_응답됨(response);
     }
 
     @DisplayName("Bearer Auth 로그인 실패")
     @Test
-    void myInfoWithBadBearerAuth() {
+    void loginWithBadBearerAuth() {
+        // when
+        ExtractableResponse<Response> response = 토큰_요청(new TokenRequest("없는이메일", "password"));
+
+        // then
+        인증_싪패(response);
     }
 
     @DisplayName("Bearer Auth 유효하지 않은 토큰")
     @Test
-    void myInfoWithWrongBearerAuth() {
+    void loginWithWrongBearerAuth() {
+        // when
+        ExtractableResponse<Response> response = 나의_정보_조회_요청("InvalidToken");
+
+        // then
+        유효하지_않은_토큰(response);
     }
 
+    private static ExtractableResponse<Response> 토큰_요청(TokenRequest params) {
+        return RestAssured
+                .given().log().all()
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(params)
+                .when().post("/login/token")
+                .then().log().all().
+                extract();
+    }
+
+    private static void 토큰_응답됨(ExtractableResponse response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    private static void 인증_싪패(ExtractableResponse response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
+
+    private static void 유효하지_않은_토큰(ExtractableResponse response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.UNAUTHORIZED.value());
+    }
 }

--- a/src/test/java/nextstep/subway/favorite/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/favorite/FavoriteAcceptanceTest.java
@@ -1,8 +1,0 @@
-package nextstep.subway.favorite;
-
-import nextstep.subway.AcceptanceTest;
-import org.junit.jupiter.api.DisplayName;
-
-@DisplayName("즐겨찾기 관련 기능")
-public class FavoriteAcceptanceTest extends AcceptanceTest {
-}

--- a/src/test/java/nextstep/subway/favorite/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/favorite/acceptance/FavoriteAcceptanceTest.java
@@ -109,6 +109,11 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
         즐겨찾기_목록_조회됨(listResponse);
         즐겨찾기_목록_포함됨(listResponse, Arrays.asList(createResponse, createResponse2));
 
+        // when
+        ExtractableResponse<Response> deleteResponse = 즐겨찾기_삭제_요청(createResponse);
+        // then
+        즐겨찾기_삭제됨(deleteResponse);
+
     }
 
     private static ExtractableResponse<Response> 즐겨찾기_생성을_요청(Long source, Long target) {
@@ -134,6 +139,16 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
                 .extract();
     }
 
+    private static ExtractableResponse<Response> 즐겨찾기_삭제_요청(ExtractableResponse<Response> response) {
+        String uri = response.header("Location");
+
+        return RestAssured
+                .given().log().all()
+                .when().delete(uri)
+                .then().log().all()
+                .extract();
+    }
+
     private static void 즐겨찾기_생성됨(ExtractableResponse<Response> response) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
     }
@@ -154,5 +169,9 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
                 .collect(Collectors.toList());
 
         assertThat(resultLineIds).containsAll(expectedLineIds);
+    }
+
+    public static void 즐겨찾기_삭제됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.NO_CONTENT.value());
     }
 }

--- a/src/test/java/nextstep/subway/favorite/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/favorite/acceptance/FavoriteAcceptanceTest.java
@@ -2,17 +2,20 @@ package nextstep.subway.favorite.acceptance;
 
 import static nextstep.subway.auth.acceptance.AuthAcceptanceTest.토큰_요청;
 import static nextstep.subway.line.acceptance.LineAcceptanceTest.지하철_노선_등록되어_있음;
-import static nextstep.subway.line.acceptance.LineSectionAcceptanceTest.지하철_노선에_지하철역_등록_요청;
 import static nextstep.subway.member.MemberAcceptanceTest.회원_생성을_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import nextstep.subway.AcceptanceTest;
 import nextstep.subway.auth.dto.TokenRequest;
 import nextstep.subway.auth.dto.TokenResponse;
 import nextstep.subway.favorite.dto.FavoriteRequest;
+import nextstep.subway.favorite.dto.FavoriteResponse;
 import nextstep.subway.line.dto.LineRequest;
 import nextstep.subway.line.dto.LineResponse;
 import nextstep.subway.station.StationAcceptanceTest;
@@ -48,6 +51,7 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
     private LineResponse 신분당선;
     private StationResponse 강남역;
     private StationResponse 양재역;
+    private StationResponse 광교역;
     private String EMAIL = "email@email.com";
     private String PASSWORD = "password";
     private int AGE = 20;
@@ -75,6 +79,8 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
         신분당선 = 지하철_노선_등록되어_있음(new LineRequest("신분당선", "bg-red-600", 강남역.getId(), 양재역.getId(), 10)).as(
                 LineResponse.class);
 
+        광교역 = StationAcceptanceTest.지하철역_등록되어_있음("광교역").as(StationResponse.class);
+
         회원_생성을_요청(EMAIL, PASSWORD, AGE);
         토큰 = 토큰_요청(new TokenRequest(EMAIL, PASSWORD)).as(TokenResponse.class).getAccessToken();
     }
@@ -95,6 +101,14 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
         ExtractableResponse<Response> createResponse = 즐겨찾기_생성을_요청(강남역.getId(), 양재역.getId());
         // then
         즐겨찾기_생성됨(createResponse);
+
+        // when
+        ExtractableResponse<Response> createResponse2 = 즐겨찾기_생성을_요청(강남역.getId(), 양재역.getId());
+        ExtractableResponse<Response> listResponse = 즐겨찾기_목록_조회_요청();
+        // then
+        즐겨찾기_목록_조회됨(listResponse);
+        즐겨찾기_목록_포함됨(listResponse, Arrays.asList(createResponse, createResponse2));
+
     }
 
     private static ExtractableResponse<Response> 즐겨찾기_생성을_요청(Long source, Long target) {
@@ -110,7 +124,35 @@ public class FavoriteAcceptanceTest extends AcceptanceTest {
                 .extract();
     }
 
+    private static ExtractableResponse<Response> 즐겨찾기_목록_조회_요청() {
+        return RestAssured
+                .given().log().all()
+                .auth().oauth2(토큰)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/favorites")
+                .then().log().all()
+                .extract();
+    }
+
     private static void 즐겨찾기_생성됨(ExtractableResponse<Response> response) {
         assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+
+    private static void 즐겨찾기_목록_조회됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.OK.value());
+    }
+
+    private static void 즐겨찾기_목록_포함됨(ExtractableResponse<Response> response,
+                                    List<ExtractableResponse<Response>> createdResponses) {
+
+        List<Long> expectedLineIds = createdResponses.stream()
+                .map(it -> Long.parseLong(it.header("Location").split("/")[2]))
+                .collect(Collectors.toList());
+
+        List<Long> resultLineIds = response.jsonPath().getList(".", FavoriteResponse.class).stream()
+                .map(FavoriteResponse::getId)
+                .collect(Collectors.toList());
+
+        assertThat(resultLineIds).containsAll(expectedLineIds);
     }
 }

--- a/src/test/java/nextstep/subway/favorite/acceptance/FavoriteAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/favorite/acceptance/FavoriteAcceptanceTest.java
@@ -1,0 +1,116 @@
+package nextstep.subway.favorite.acceptance;
+
+import static nextstep.subway.auth.acceptance.AuthAcceptanceTest.토큰_요청;
+import static nextstep.subway.line.acceptance.LineAcceptanceTest.지하철_노선_등록되어_있음;
+import static nextstep.subway.line.acceptance.LineSectionAcceptanceTest.지하철_노선에_지하철역_등록_요청;
+import static nextstep.subway.member.MemberAcceptanceTest.회원_생성을_요청;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.restassured.RestAssured;
+import io.restassured.response.ExtractableResponse;
+import io.restassured.response.Response;
+import nextstep.subway.AcceptanceTest;
+import nextstep.subway.auth.dto.TokenRequest;
+import nextstep.subway.auth.dto.TokenResponse;
+import nextstep.subway.favorite.dto.FavoriteRequest;
+import nextstep.subway.line.dto.LineRequest;
+import nextstep.subway.line.dto.LineResponse;
+import nextstep.subway.station.StationAcceptanceTest;
+import nextstep.subway.station.dto.StationResponse;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+
+
+/**
+ * Feature: 즐겨찾기를 관리한다.
+ * <p>
+ * Scenario: 즐겨찾기를 관리
+ * <p>
+ * When 즐겨찾기 생성을 요청
+ * <p>
+ * Then 즐겨찾기 생성됨
+ * <p>
+ * When 즐겨찾기 목록 조회 요청
+ * <p>
+ * Then 즐겨찾기 목록 조회됨
+ * <p>
+ * When 즐겨찾기 삭제 요청
+ * <p>
+ * Then 즐겨찾기 삭제됨
+ */
+
+@DisplayName("즐겨찾기 관련 기능")
+public class FavoriteAcceptanceTest extends AcceptanceTest {
+
+    private LineResponse 신분당선;
+    private StationResponse 강남역;
+    private StationResponse 양재역;
+    private String EMAIL = "email@email.com";
+    private String PASSWORD = "password";
+    private int AGE = 20;
+    private static String 토큰;
+
+    /**
+     * Background
+     * <p>
+     * Given 지하철역 등록되어 있음
+     * <p>
+     * And 지하철 노선 등록되어 있음
+     * <p>
+     * And 지하철 노선에 지하철역 등록되어 있음
+     * <p>
+     * And 회원 등록되어 있음
+     * <p>
+     * And 로그인 되어있음
+     */
+    @BeforeEach
+    public void setUp() {
+        super.setUp();
+
+        강남역 = StationAcceptanceTest.지하철역_등록되어_있음("강남역").as(StationResponse.class);
+        양재역 = StationAcceptanceTest.지하철역_등록되어_있음("양재역").as(StationResponse.class);
+        신분당선 = 지하철_노선_등록되어_있음(new LineRequest("신분당선", "bg-red-600", 강남역.getId(), 양재역.getId(), 10)).as(
+                LineResponse.class);
+
+        회원_생성을_요청(EMAIL, PASSWORD, AGE);
+        토큰 = 토큰_요청(new TokenRequest(EMAIL, PASSWORD)).as(TokenResponse.class).getAccessToken();
+    }
+
+    @DisplayName("즐겨찾기를 관리한다.")
+    @Test
+    void manageFavorite() {
+        /**
+         * When 즐겨찾기 생성을 요청
+         *     Then 즐겨찾기 생성됨
+         *     When 즐겨찾기 목록 조회 요청
+         *     Then 즐겨찾기 목록 조회됨
+         *     When 즐겨찾기 삭제 요청
+         *     Then 즐겨찾기 삭제됨
+         */
+
+        // when
+        ExtractableResponse<Response> createResponse = 즐겨찾기_생성을_요청(강남역.getId(), 양재역.getId());
+        // then
+        즐겨찾기_생성됨(createResponse);
+    }
+
+    private static ExtractableResponse<Response> 즐겨찾기_생성을_요청(Long source, Long target) {
+        FavoriteRequest favoriteRequest = new FavoriteRequest(source, target);
+
+        return RestAssured
+                .given().log().all()
+                .auth().oauth2(토큰)
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(favoriteRequest)
+                .when().post("/favorites")
+                .then().log().all()
+                .extract();
+    }
+
+    private static void 즐겨찾기_생성됨(ExtractableResponse<Response> response) {
+        assertThat(response.statusCode()).isEqualTo(HttpStatus.CREATED.value());
+    }
+}

--- a/src/test/java/nextstep/subway/favorite/domain/FavoriteRepositoryTest.java
+++ b/src/test/java/nextstep/subway/favorite/domain/FavoriteRepositoryTest.java
@@ -1,0 +1,45 @@
+package nextstep.subway.favorite.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+
+import nextstep.subway.member.domain.Member;
+import nextstep.subway.member.domain.MemberRepository;
+import nextstep.subway.station.domain.Station;
+import nextstep.subway.station.domain.StationRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+
+@DataJpaTest
+class FavoriteRepositoryTest {
+    private Station 강남역;
+    private Station 양재역;
+    private Member 회원;
+
+    @Autowired
+    private FavoriteRepository favoriteRepository;
+    @Autowired
+    private StationRepository stationRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @BeforeEach
+    void setUp() {
+        회원 = memberRepository.save(new Member("email@email.com", "password", 20));
+        강남역 = stationRepository.save(new Station("강남역"));
+        양재역 = stationRepository.save(new Station("양재역"));
+    }
+
+    @Test
+    void 즐겨찾기_생성() {
+        Favorite favorite = favoriteRepository.save(new Favorite.Builder()
+                .member(회원)
+                .source(강남역)
+                .target(양재역)
+                .build());
+
+        assertThat(favorite).isNotNull();
+    }
+}

--- a/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
@@ -71,10 +71,15 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         회원_생성을_요청(EMAIL, PASSWORD, AGE);
 
         // when
-        ExtractableResponse<Response> response = 나의_정보_조회_요청(EMAIL, PASSWORD);
-
+        ExtractableResponse<Response> MyResponse = 나의_정보_조회_요청(EMAIL, PASSWORD);
         // then
-        회원_정보_조회됨(response, EMAIL, AGE);
+        회원_정보_조회됨(MyResponse, EMAIL, AGE);
+
+        // when
+        ExtractableResponse<Response> updateResponse = 나의_정보_변경_요청(NEW_EMAIL, NEW_PASSWORD, NEW_AGE);
+        // then
+        회원_정보_수정됨(updateResponse);
+
     }
 
     public static ExtractableResponse<Response> 회원_생성을_요청(String email, String password, Integer age) {
@@ -134,12 +139,26 @@ public class MemberAcceptanceTest extends AcceptanceTest {
     }
 
     public static ExtractableResponse<Response> 나의_정보_조회_요청(String email, String password) {
-        TokenResponse tokenResponse = 토큰_요청(new TokenRequest(EMAIL, PASSWORD)).as(TokenResponse.class);
+        TokenResponse tokenResponse = 토큰_요청(new TokenRequest(email, password)).as(TokenResponse.class);
         return RestAssured
                 .given().log().all()
                 .auth().oauth2(tokenResponse.getAccessToken())
-                .accept(MediaType.APPLICATION_JSON_VALUE)
                 .when().get("/members/me")
+                .then().log().all()
+                .extract();
+    }
+
+
+    public static ExtractableResponse<Response> 나의_정보_변경_요청(String email, String password, Integer age) {
+        TokenResponse tokenResponse = 토큰_요청(new TokenRequest(EMAIL, PASSWORD)).as(TokenResponse.class);
+        MemberRequest memberRequest = new MemberRequest(email, password, age);
+
+        return RestAssured
+                .given().log().all()
+                .auth().oauth2(tokenResponse.getAccessToken())
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .body(memberRequest)
+                .when().put("/members/me")
                 .then().log().all()
                 .extract();
     }

--- a/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
@@ -4,6 +4,7 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
+import nextstep.subway.auth.dto.TokenRequest;
 import nextstep.subway.auth.dto.TokenResponse;
 import nextstep.subway.member.dto.MemberRequest;
 import nextstep.subway.member.dto.MemberResponse;
@@ -13,6 +14,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
+import static nextstep.subway.auth.acceptance.AuthAcceptanceTest.토큰_요청;
 import static org.assertj.core.api.Assertions.assertThat;
 
 public class MemberAcceptanceTest extends AcceptanceTest {
@@ -47,10 +49,32 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         회원_삭제됨(deleteResponse);
     }
 
+    /**
+     * given 나의 정보가 생성되어 있음
+     * <p>
+     * when 나의 정보를 조회하면
+     * <p>
+     * then 나의 정보가 조회가 조회됨
+     * <p>
+     * when 나의 정보를 수정하면
+     * <p>
+     * then 나의 정보가 수정됨
+     * <p>
+     * when 나의 정보를 삭제하면
+     * <p>
+     * then 나의 정보가 삭제됨
+     */
     @DisplayName("나의 정보를 관리한다.")
     @Test
     void manageMyInfo() {
+        // given
+        회원_생성을_요청(EMAIL, PASSWORD, AGE);
 
+        // when
+        ExtractableResponse<Response> response = 나의_정보_조회_요청(EMAIL, PASSWORD);
+
+        // then
+        회원_정보_조회됨(response, EMAIL, AGE);
     }
 
     public static ExtractableResponse<Response> 회원_생성을_요청(String email, String password, Integer age) {
@@ -103,6 +127,17 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         return RestAssured
                 .given().log().all()
                 .auth().oauth2(token)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/members/me")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 나의_정보_조회_요청(String email, String password) {
+        TokenResponse tokenResponse = 토큰_요청(new TokenRequest(EMAIL, PASSWORD)).as(TokenResponse.class);
+        return RestAssured
+                .given().log().all()
+                .auth().oauth2(tokenResponse.getAccessToken())
                 .accept(MediaType.APPLICATION_JSON_VALUE)
                 .when().get("/members/me")
                 .then().log().all()

--- a/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
@@ -4,10 +4,12 @@ import io.restassured.RestAssured;
 import io.restassured.response.ExtractableResponse;
 import io.restassured.response.Response;
 import nextstep.subway.AcceptanceTest;
+import nextstep.subway.auth.dto.TokenResponse;
 import nextstep.subway.member.dto.MemberRequest;
 import nextstep.subway.member.dto.MemberResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 
@@ -74,7 +76,8 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .extract();
     }
 
-    public static ExtractableResponse<Response> 회원_정보_수정_요청(ExtractableResponse<Response> response, String email, String password, Integer age) {
+    public static ExtractableResponse<Response> 회원_정보_수정_요청(ExtractableResponse<Response> response, String email,
+                                                            String password, Integer age) {
         String uri = response.header("Location");
         MemberRequest memberRequest = new MemberRequest(email, password, age);
 
@@ -92,6 +95,16 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         return RestAssured
                 .given().log().all()
                 .when().delete(uri)
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 나의_정보_조회_요청(String token) {
+        return RestAssured
+                .given().log().all()
+                .auth().oauth2(token)
+                .accept(MediaType.APPLICATION_JSON_VALUE)
+                .when().get("/members/me")
                 .then().log().all()
                 .extract();
     }

--- a/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
+++ b/src/test/java/nextstep/subway/member/MemberAcceptanceTest.java
@@ -80,6 +80,11 @@ public class MemberAcceptanceTest extends AcceptanceTest {
         // then
         회원_정보_수정됨(updateResponse);
 
+        // when
+        ExtractableResponse<Response> deleteResponse = 나의_정보_삭제_요청(EMAIL, PASSWORD);
+        // then
+        회원_삭제됨(deleteResponse);
+
     }
 
     public static ExtractableResponse<Response> 회원_생성을_요청(String email, String password, Integer age) {
@@ -159,6 +164,17 @@ public class MemberAcceptanceTest extends AcceptanceTest {
                 .contentType(MediaType.APPLICATION_JSON_VALUE)
                 .body(memberRequest)
                 .when().put("/members/me")
+                .then().log().all()
+                .extract();
+    }
+
+    public static ExtractableResponse<Response> 나의_정보_삭제_요청(String email, String password) {
+        TokenResponse tokenResponse = 토큰_요청(new TokenRequest(EMAIL, PASSWORD)).as(TokenResponse.class);
+
+        return RestAssured
+                .given().log().all()
+                .auth().oauth2(tokenResponse.getAccessToken())
+                .when().delete("/members/me")
                 .then().log().all()
                 .extract();
     }


### PR DESCRIPTION
### 지난 Pr 관련 사항
- https://github.com/next-step/atdd-subway-service/pull/588#discussion_r897432897 : 리뷰어님의 의견에 매우 동의 합니다. 그런데 현재 PathFinder 를 Spring Component로 등록해, 서비스 계층에서 주입하고 있는데, PathFinder를 생성 시 생성자로 Lines를 인자로 받을 수 있는 방법이 있을까요. 해당 방법을 찾지못해 우선 대응하지 못했습니다ㅜ
- https://github.com/next-step/atdd-subway-service/pull/588#discussion_r897433155 : 사실 값 객체를 만들 때, 생성자를 private로 하고, 정적 팩토리를 만들어 사용하는것을 습관처럼 사용하고 있었습니다. 그래도 해당 이유에 대해서 생각 해 본다면, 객체 생성을 캡슐화 할 수 있다는 정도의 장점은 있을 것 같습니다.

### 변경 사항

- 로그인 인수 테스트 작성
- 내 정보 조회 기능 완성
- 즐겨 찾기 기능 구현


이번 리뷰도 잘 부탁드립니다 ㅎㅎ
감사합니다.